### PR TITLE
Feature/low touch onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Creates a complete Kubernetes environment with ArgoCD, networking, and certifica
 - **Minimum**: 24GB RAM, 6 CPU cores, 50GB disk
 - **Recommended**: 32GB RAM, 12 CPU cores, 100GB disk
 - Docker installed and running
+- **Windows**: WSL2 with Ubuntu (automatically configured during bootstrap)
 
 ### Installation
 
@@ -78,17 +79,34 @@ sudo mv openframe-cli /usr/local/bin/openframe
 # Verify installation
 openframe --version
 
-# Create complete OpenFrame environment
+# Interactive — walks you through deployment mode and configuration
 openframe bootstrap
+
+# One-liner with no prompts — ideal for getting started fast
+openframe bootstrap --deployment-mode=oss-tenant
+
+# Full CI/CD mode — zero interaction, uses existing helm-values.yaml
+openframe bootstrap --deployment-mode=oss-tenant --non-interactive
+
+# Continue past memory warnings (useful for machines with <24GB RAM)
+openframe bootstrap --force
 ```
 
 This single command will:
-1. ✅ Check prerequisites and install missing tools
-2. ✅ Create K3D cluster with networking configuration
-3. ✅ Install ArgoCD for GitOps continuous delivery
-4. ✅ Deploy application charts using app-of-apps pattern
-5. ✅ Configure local HTTPS certificates
-6. ✅ Verify all services are healthy and running
+
+1. ✅ Run a unified pre-flight check — validates **all** prerequisites (tools, memory, certificates) upfront
+2. ✅ Auto-install missing tools (K3D, Helm, kubectl, mkcert) across macOS, Linux, and Windows/WSL2
+3. ✅ Create K3D cluster with networking configuration
+4. ✅ Install ArgoCD for GitOps continuous delivery
+5. ✅ Deploy application charts using app-of-apps pattern
+6. ✅ Configure local HTTPS certificates
+7. ✅ Verify all services are healthy and running
+
+> **Contributing from a fork?** Use `--repo` and `--branch` to point bootstrap at your fork:
+>
+> ```bash
+> openframe bootstrap --repo=https://github.com/myorg/openframe-oss-tenant --branch=my-feature
+> ```
 
 ### Access Your Environment
 
@@ -166,6 +184,12 @@ openframe bootstrap --deployment-mode=oss-tenant
 
 # Non-interactive with custom configuration
 openframe bootstrap --deployment-mode=saas-shared --non-interactive
+
+# Force past memory warnings
+openframe bootstrap --deployment-mode=oss-tenant --force
+
+# Bootstrap from a fork or feature branch
+openframe bootstrap --repo=https://github.com/myorg/openframe-oss-tenant --branch=dev
 
 # Cluster management with custom settings
 openframe cluster create --nodes 5 --type k3d --version v1.31.5-k3s1

--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -13,8 +13,9 @@ func GetBootstrapCmd() *cobra.Command {
 		Long: `Bootstrap Complete OpenFrame Environment
 
 This command performs a complete OpenFrame setup by running:
-1. openframe cluster create - Creates a Kubernetes cluster
-2. openframe chart install - Installs ArgoCD and OpenFrame charts
+1. Pre-flight check - Validates ALL prerequisites (tools, memory, certificates) upfront
+2. openframe cluster create - Creates a Kubernetes cluster
+3. openframe chart install - Installs ArgoCD and OpenFrame charts
 
 This is equivalent to running both commands sequentially but provides
 a streamlined experience for getting started with OpenFrame.
@@ -25,18 +26,23 @@ Examples:
   openframe bootstrap --deployment-mode=oss-tenant     # Skip deployment selection
   openframe bootstrap --deployment-mode=saas-shared --non-interactive  # Full CI/CD mode
   openframe bootstrap --verbose                         # Show detailed logs including ArgoCD sync progress
-  openframe bootstrap -v --deployment-mode=oss-tenant  # Verbose mode with pre-selected deployment`,
+  openframe bootstrap -v --deployment-mode=oss-tenant  # Verbose mode with pre-selected deployment
+  openframe bootstrap --repo=https://github.com/myorg/myrepo --branch=dev  # Custom repository`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Logo will be shown by cluster wrapper before prerequisites
 			return bootstrap.NewService().Execute(cmd, args)
 		},
 	}
 
-	// Add deployment mode flags
+	// Deployment configuration
 	cmd.Flags().String("deployment-mode", "", "Deployment mode: oss-tenant, saas-tenant, saas-shared (skips deployment selection)")
 	cmd.Flags().Bool("non-interactive", false, "Skip all prompts, use existing helm-values.yaml")
 	cmd.Flags().BoolP("verbose", "v", false, "Show detailed logging including ArgoCD sync progress")
+	cmd.Flags().Bool("force", false, "Continue even with insufficient memory or other warnings")
+
+	// Repository overrides (useful for contributors working on forks)
+	cmd.Flags().String("repo", "", "Override the default GitHub repository URL")
+	cmd.Flags().String("branch", "", "Override the default Git branch (default: main)")
 
 	return cmd
 }

--- a/internal/bootstrap/preflight.go
+++ b/internal/bootstrap/preflight.go
@@ -1,0 +1,331 @@
+package bootstrap
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	chartCerts "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/certificates"
+	chartGit "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/git"
+	chartHelm "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/helm"
+	chartMemory "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/memory"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/docker"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/k3d"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/kubectl"
+	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/pterm/pterm"
+)
+
+// PreflightChecker runs all prerequisite checks upfront before any work begins.
+// This unifies the cluster and chart prerequisite gates so users don't create a
+// cluster only to fail on chart prerequisites.
+type PreflightChecker struct {
+	nonInteractive bool
+	force          bool
+	verbose        bool
+}
+
+// NewPreflightChecker creates a new unified preflight checker.
+func NewPreflightChecker(nonInteractive, force, verbose bool) *PreflightChecker {
+	return &PreflightChecker{
+		nonInteractive: nonInteractive,
+		force:          force,
+		verbose:        verbose,
+	}
+}
+
+// preflightTool represents a tool to check during preflight.
+type preflightTool struct {
+	Name        string
+	Category    string // "cluster" or "chart"
+	IsInstalled func() bool
+	InstallHelp func() string
+	Installable bool // false for things like memory
+}
+
+// CheckAll runs all prerequisite checks and installs missing tools.
+// It checks cluster prerequisites (Docker, kubectl, k3d, helm) and chart
+// prerequisites (git, helm, memory, certificates) in a single pass.
+func (p *PreflightChecker) CheckAll() error {
+	// Phase 1: Check memory upfront — fail fast if insufficient
+	if err := p.checkMemory(); err != nil {
+		return err
+	}
+
+	// Phase 2: Check all tools
+	tools := p.getAllTools()
+	var missing []preflightTool
+
+	for _, tool := range tools {
+		if !tool.IsInstalled() {
+			missing = append(missing, tool)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Separate truly missing (installable) from Docker-not-running
+	var installable []preflightTool
+	var dockerNotRunning bool
+
+	for _, tool := range missing {
+		if tool.Name == "Docker" {
+			if docker.NewDockerInstaller().IsInstalled() {
+				dockerNotRunning = true
+			} else {
+				installable = append(installable, tool)
+			}
+		} else {
+			installable = append(installable, tool)
+		}
+	}
+
+	// Phase 3: Install missing tools
+	if len(installable) > 0 {
+		names := make([]string, len(installable))
+		for i, t := range installable {
+			names[i] = t.Name
+		}
+		pterm.Warning.Printf("Missing Prerequisites: %s\n", strings.Join(names, ", "))
+
+		var confirmed bool
+		if p.nonInteractive {
+			pterm.Info.Println("Auto-installing prerequisites (non-interactive mode)...")
+			confirmed = true
+		} else {
+			var err error
+			confirmed, err = ui.ConfirmActionInteractive("Would you like me to install them automatically?", true)
+			if err := sharedErrors.WrapConfirmationError(err, "failed to get user confirmation"); err != nil {
+				return err
+			}
+		}
+
+		if confirmed {
+			if err := p.installTools(installable); err != nil {
+				if p.nonInteractive {
+					pterm.Warning.Printf("Failed to install some prerequisites: %v\n", err)
+					pterm.Info.Println("Continuing anyway (non-interactive mode)...")
+				} else {
+					return err
+				}
+			}
+		} else {
+			p.showManualInstructions(installable)
+			return fmt.Errorf("prerequisites not installed")
+		}
+	}
+
+	// Phase 4: Start Docker if needed
+	if dockerNotRunning {
+		if err := p.startDocker(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkMemory validates system memory against the recommended minimum.
+func (p *PreflightChecker) checkMemory() error {
+	memChecker := chartMemory.NewMemoryChecker()
+	current, recommended, sufficient := memChecker.GetMemoryInfo()
+
+	if !sufficient {
+		pterm.Warning.Printf("Memory Warning: %d MB available, %d MB recommended\n", current, recommended)
+		if p.force {
+			pterm.Info.Println("Continuing anyway (--force specified).")
+			return nil
+		}
+		if p.nonInteractive {
+			pterm.Info.Println("Continuing anyway (non-interactive mode).")
+			return nil
+		}
+		pterm.Info.Println("Charts may not deploy successfully with insufficient memory.")
+		confirmed, err := ui.ConfirmActionInteractive("Continue anyway?", false)
+		if err != nil {
+			return fmt.Errorf("failed to get memory confirmation: %w", err)
+		}
+		if !confirmed {
+			return fmt.Errorf("insufficient memory: %d MB available, %d MB recommended. Use --force to override", current, recommended)
+		}
+	}
+	return nil
+}
+
+// getAllTools returns all prerequisite tools for both cluster and chart phases.
+func (p *PreflightChecker) getAllTools() []preflightTool {
+	return []preflightTool{
+		// Cluster prerequisites
+		{
+			Name:        "Docker",
+			Category:    "cluster",
+			IsInstalled: func() bool { return docker.IsDockerRunning() },
+			InstallHelp: func() string { return docker.NewDockerInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "kubectl",
+			Category:    "cluster",
+			IsInstalled: func() bool { return kubectl.NewKubectlInstaller().IsInstalled() },
+			InstallHelp: func() string { return kubectl.NewKubectlInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "k3d",
+			Category:    "cluster",
+			IsInstalled: func() bool { return k3d.NewK3dInstaller().IsInstalled() },
+			InstallHelp: func() string { return k3d.NewK3dInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "Helm",
+			Category:    "cluster",
+			IsInstalled: func() bool { return chartHelm.NewHelmInstaller().IsInstalled() },
+			InstallHelp: func() string { return chartHelm.NewHelmInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		// Chart prerequisites (excluding memory — handled separately)
+		{
+			Name:        "Git",
+			Category:    "chart",
+			IsInstalled: func() bool { return chartGit.NewGitChecker().IsInstalled() },
+			InstallHelp: func() string { return chartGit.NewGitChecker().GetInstallInstructions() },
+			Installable: false, // git install is manual
+		},
+		{
+			Name:        "Certificates",
+			Category:    "chart",
+			IsInstalled: func() bool { return chartCerts.NewCertificateInstaller().IsInstalled() },
+			InstallHelp: func() string { return chartCerts.NewCertificateInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+	}
+}
+
+// installTools installs the given list of missing tools.
+func (p *PreflightChecker) installTools(tools []preflightTool) error {
+	for idx, tool := range tools {
+		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("[%d/%d] Installing %s...", idx+1, len(tools), tool.Name))
+
+		if err := p.installTool(tool); err != nil {
+			if p.nonInteractive {
+				spinner.Warning(fmt.Sprintf("Skipped %s: %v", tool.Name, err))
+				continue
+			}
+			spinner.Fail(fmt.Sprintf("Failed to install %s: %v", tool.Name, err))
+			return fmt.Errorf("failed to install %s: %w", tool.Name, err)
+		}
+
+		spinner.Success(fmt.Sprintf("%s installed successfully", tool.Name))
+	}
+	return nil
+}
+
+// installTool installs a single tool by name.
+func (p *PreflightChecker) installTool(tool preflightTool) error {
+	switch tool.Name {
+	case "Docker":
+		return docker.NewDockerInstaller().Install()
+	case "kubectl":
+		return kubectl.NewKubectlInstaller().Install()
+	case "k3d":
+		return k3d.NewK3dInstaller().Install()
+	case "Helm":
+		return chartHelm.NewHelmInstaller().Install()
+	case "Certificates":
+		if p.nonInteractive {
+			pterm.Info.Println("Skipping certificate generation in non-interactive mode")
+			return nil
+		}
+		return chartCerts.NewCertificateInstaller().Install()
+	case "Git":
+		return fmt.Errorf("git is not installed. %s", chartGit.NewGitChecker().GetInstallInstructions())
+	default:
+		return fmt.Errorf("unknown tool: %s", tool.Name)
+	}
+}
+
+// startDocker attempts to start Docker.
+func (p *PreflightChecker) startDocker() error {
+	if p.nonInteractive {
+		pterm.Warning.Println("Docker is not running.")
+		pterm.Info.Println("Attempting to start Docker automatically (non-interactive mode)...")
+
+		if err := docker.StartDocker(); err != nil {
+			pterm.Warning.Printf("Could not start Docker automatically: %v\n", err)
+			pterm.Info.Println("Docker must be started manually.")
+			return nil
+		}
+
+		spinner, _ := pterm.DefaultSpinner.Start("Waiting for Docker to start...")
+		if err := docker.WaitForDocker(); err != nil {
+			spinner.Warning("Docker failed to start automatically")
+			return nil
+		}
+		spinner.Success("Docker started successfully")
+		return nil
+	}
+
+	pterm.Warning.Println("Docker is not running.")
+	confirmed, err := ui.ConfirmActionInteractive("Would you like me to start Docker for you?", true)
+	if err != nil {
+		return fmt.Errorf("failed to get Docker start confirmation: %w", err)
+	}
+
+	if confirmed {
+		if err := docker.StartDocker(); err != nil {
+			pterm.Error.Printf("Failed to start Docker: %v\n", err)
+			pterm.Info.Println("Please start Docker Desktop manually and try again.")
+			return fmt.Errorf("failed to start Docker: %w", err)
+		}
+		spinner, _ := pterm.DefaultSpinner.Start("Waiting for Docker to start...")
+		if err := docker.WaitForDocker(); err != nil {
+			spinner.Fail("Docker failed to start")
+			return fmt.Errorf("Docker failed to start: %w", err)
+		}
+		spinner.Success("Docker started successfully")
+	} else {
+		p.showDockerStartInstructions()
+		return fmt.Errorf("Docker is not running")
+	}
+
+	return nil
+}
+
+// showManualInstructions displays manual installation instructions for missing tools.
+func (p *PreflightChecker) showManualInstructions(tools []preflightTool) {
+	fmt.Println()
+	pterm.Info.Println("Installation skipped. Here are manual installation instructions:")
+
+	tableData := pterm.TableData{{"Tool", "Installation Instructions"}}
+	for _, tool := range tools {
+		help := tool.InstallHelp()
+		parts := strings.SplitN(help, ": ", 2)
+		if len(parts) == 2 {
+			tableData = append(tableData, []string{pterm.Cyan(parts[0]), parts[1]})
+		} else {
+			tableData = append(tableData, []string{pterm.Cyan(tool.Name), help})
+		}
+	}
+
+	pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}
+
+// showDockerStartInstructions displays platform-specific Docker start instructions.
+func (p *PreflightChecker) showDockerStartInstructions() {
+	fmt.Println()
+	pterm.Info.Println("Please start Docker manually and try again:")
+	switch runtime.GOOS {
+	case "darwin":
+		pterm.Printf("  Open Docker Desktop or run: %s\n", pterm.Cyan("open -a Docker"))
+	case "linux":
+		pterm.Printf("  %s\n", pterm.Cyan("sudo systemctl start docker"))
+	case "windows":
+		pterm.Printf("  Start Docker Desktop from Start Menu\n")
+	default:
+		pterm.Printf("  Verify Docker is running: %s\n", pterm.Cyan("docker ps"))
+	}
+}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 )
@@ -47,6 +48,22 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 		nonInteractive = false
 	}
 
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		force = false
+	}
+
+	// Get repo/branch overrides
+	githubRepo, err := cmd.Flags().GetString("repo")
+	if err != nil {
+		githubRepo = ""
+	}
+
+	githubBranch, err := cmd.Flags().GetString("branch")
+	if err != nil {
+		githubBranch = ""
+	}
+
 	// Validate deployment mode
 	if deploymentMode != "" {
 		validModes := []string{"oss-tenant", "saas-tenant", "saas-shared"}
@@ -73,7 +90,7 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 		clusterName = strings.TrimSpace(args[0])
 	}
 
-	err = s.bootstrap(clusterName, deploymentMode, nonInteractive, verbose)
+	err = s.bootstrap(clusterName, deploymentMode, nonInteractive, force, verbose, githubRepo, githubBranch)
 	if err != nil {
 		// Use shared error handler for consistent error display (same as chart install)
 		return sharedErrors.HandleGlobalError(err, verbose)
@@ -82,7 +99,10 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 }
 
 // bootstrap executes cluster create followed by chart install
-func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, verbose bool) error {
+func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, force, verbose bool, githubRepo, githubBranch string) error {
+	// Show logo first
+	ui.ShowLogo()
+
 	// On Windows, initialize WSL2 first before anything else
 	if runtime.GOOS == "windows" {
 		if err := s.initializeWSL(verbose); err != nil {
@@ -90,12 +110,20 @@ func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, 
 		}
 	}
 
+	// Unified pre-flight check: verify ALL prerequisites (cluster + chart) before
+	// creating a cluster. This prevents the user from waiting 5-10 minutes for
+	// cluster creation only to fail on chart prerequisites like memory or mkcert.
+	preflight := NewPreflightChecker(nonInteractive, force, verbose)
+	if err := preflight.CheckAll(); err != nil {
+		return err
+	}
+
 	// Normalize cluster name (use default if empty)
 	config := s.buildClusterConfig(clusterName)
 	actualClusterName := config.Name
 
-	// Step 1: Create cluster with suppressed UI and get the rest.Config
-	kubeConfig, err := s.createClusterSuppressed(actualClusterName, verbose, nonInteractive)
+	// Step 1: Create cluster (skip prerequisite checks — already done above)
+	kubeConfig, err := s.createClusterSkipPrereqs(actualClusterName, verbose, nonInteractive)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster: %w", err)
 	}
@@ -105,18 +133,18 @@ func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, 
 	fmt.Println()
 
 	// Step 2: Install charts with deployment mode flags on the created cluster
-	if err := s.installChartWithMode(actualClusterName, deploymentMode, nonInteractive, verbose, kubeConfig); err != nil {
+	// Skip chart prerequisites — already checked by preflight
+	if err := s.installChartWithMode(actualClusterName, deploymentMode, nonInteractive, verbose, kubeConfig, githubRepo, githubBranch); err != nil {
 		return fmt.Errorf("failed to install charts: %w", err)
 	}
 
 	return nil
 }
 
-// createClusterSuppressed creates a cluster with suppressed UI elements
-// Returns the *rest.Config for the created cluster
-func (s *Service) createClusterSuppressed(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
-	// Use the wrapper function that includes prerequisite checks
-	return cluster.CreateClusterWithPrerequisitesNonInteractive(clusterName, verbose, nonInteractive)
+// createClusterSkipPrereqs creates a cluster without re-running prerequisite checks.
+// Prerequisites have already been verified by the unified preflight checker.
+func (s *Service) createClusterSkipPrereqs(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
+	return cluster.CreateClusterSkipPrerequisites(clusterName, verbose, nonInteractive)
 }
 
 // buildClusterConfig builds a cluster configuration from the cluster name
@@ -134,19 +162,28 @@ func (s *Service) buildClusterConfig(clusterName string) models.ClusterConfig {
 }
 
 // installChartWithMode installs charts with deployment mode flags
-func (s *Service) installChartWithMode(clusterName, deploymentMode string, nonInteractive, verbose bool, kubeConfig *rest.Config) error {
-	// Use the chart installation function with deployment mode flags
+func (s *Service) installChartWithMode(clusterName, deploymentMode string, nonInteractive, verbose bool, kubeConfig *rest.Config, githubRepo, githubBranch string) error {
+	// Determine repo URL — use override if provided, otherwise derive from deployment mode
+	if githubRepo == "" {
+		githubRepo = "https://github.com/flamingo-stack/openframe-oss-tenant"
+	}
+	if githubBranch == "" {
+		githubBranch = "main"
+	}
+
 	return chartServices.InstallChartsWithConfig(utilTypes.InstallationRequest{
-		Args:           []string{clusterName},
-		Force:          false,
-		DryRun:         false,
-		Verbose:        verbose,
-		GitHubRepo:     "https://github.com/flamingo-stack/openframe-oss-tenant", // Default repository
-		GitHubBranch:   "main",                                                   // Default branch
-		CertDir:        "",                                                       // Auto-detected
-		DeploymentMode: deploymentMode,
-		NonInteractive: nonInteractive,
-		KubeConfig:     kubeConfig,
+		Args:              []string{clusterName},
+		Force:             false,
+		DryRun:            false,
+		Verbose:           verbose,
+		GitHubRepo:        githubRepo,
+		GitHubBranch:      githubBranch,
+		CertDir:           "", // Auto-detected
+		DeploymentMode:    deploymentMode,
+		NonInteractive:    nonInteractive,
+		KubeConfig:        kubeConfig,
+		SkipPrerequisites: true,                // Already checked by preflight
+		SkipConfigPrompts: deploymentMode != "", // Skip config mode selection when deployment mode is pre-set
 	})
 }
 

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -163,10 +163,8 @@ func (s *Service) buildClusterConfig(clusterName string) models.ClusterConfig {
 
 // installChartWithMode installs charts with deployment mode flags
 func (s *Service) installChartWithMode(clusterName, deploymentMode string, nonInteractive, verbose bool, kubeConfig *rest.Config, githubRepo, githubBranch string) error {
-	// Determine repo URL — use override if provided, otherwise derive from deployment mode
-	if githubRepo == "" {
-		githubRepo = "https://github.com/flamingo-stack/openframe-oss-tenant"
-	}
+	// githubRepo is left empty when user didn't pass --repo;
+	// buildConfiguration() will derive it from deployment mode.
 	if githubBranch == "" {
 		githubBranch = "main"
 	}

--- a/internal/chart/prerequisites/certificates/certificates.go
+++ b/internal/chart/prerequisites/certificates/certificates.go
@@ -170,6 +170,12 @@ func (c *CertificateInstaller) installMkcertLinux() error {
 		return fmt.Errorf("failed to make mkcert executable: %w", err)
 	}
 
+	// Add ~/bin to PATH for the current process so generateCertificates() can find mkcert
+	currentPath := os.Getenv("PATH")
+	if !strings.Contains(currentPath, binDir) {
+		os.Setenv("PATH", binDir+":"+currentPath)
+	}
+
 	return nil
 }
 

--- a/internal/chart/prerequisites/certificates/certificates.go
+++ b/internal/chart/prerequisites/certificates/certificates.go
@@ -109,6 +109,11 @@ func (c *CertificateInstaller) ForceRegenerate() error {
 		return fmt.Errorf("mkcert is not installed")
 	}
 
+	// Ensure ~/bin is in PATH if that's where mkcert lives (Linux/macOS)
+	if runtime.GOOS != "windows" {
+		c.ensureMkcertInPath()
+	}
+
 	// Always regenerate certificates
 	return c.generateCertificates()
 }

--- a/internal/chart/prerequisites/helm/helm.go
+++ b/internal/chart/prerequisites/helm/helm.go
@@ -88,69 +88,13 @@ func (h *HelmInstaller) installMacOS() error {
 }
 
 func (h *HelmInstaller) installLinux() error {
-	if commandExists("apt") {
-		return h.installUbuntu()
-	} else if commandExists("yum") {
-		return h.installRedHat()
-	} else if commandExists("dnf") {
-		return h.installFedora()
-	} else if commandExists("pacman") {
-		return h.installArch()
-	} else {
-		return h.installScript()
-	}
-}
-
-func (h *HelmInstaller) installUbuntu() error {
-	commands := []string{
-		"curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null",
-		"sudo apt-get install apt-transport-https --yes",
-		"echo \"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main\" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list",
-		"sudo apt-get update",
-		"sudo apt-get install helm",
-	}
-
-	for _, cmd := range commands {
-		if err := h.runShellCommand(cmd); err != nil {
-			return fmt.Errorf("failed to run command '%s': %w", cmd, err)
-		}
-	}
-
-	return nil
-}
-
-func (h *HelmInstaller) installRedHat() error {
-	commands := []string{
-		"curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash",
-	}
-
-	for _, cmd := range commands {
-		if err := h.runShellCommand(cmd); err != nil {
-			return fmt.Errorf("failed to run command '%s': %w", cmd, err)
-		}
-	}
-
-	return nil
-}
-
-func (h *HelmInstaller) installFedora() error {
-	if err := h.runCommand("sudo", "dnf", "install", "-y", "helm"); err != nil {
-		// If dnf package not available, fall back to script
-		return h.installScript()
-	}
-	return nil
-}
-
-func (h *HelmInstaller) installArch() error {
-	if err := h.runCommand("sudo", "pacman", "-S", "--noconfirm", "helm"); err != nil {
-		return fmt.Errorf("failed to install Helm: %w", err)
-	}
-	return nil
+	// Use the official Helm install script — works reliably across all distros
+	// without requiring repo setup, GPG key imports, or package manager specifics.
+	return h.installScript()
 }
 
 func (h *HelmInstaller) installScript() error {
-	// Use the official Helm install script
-	installCmd := "curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+	installCmd := "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
 
 	if err := h.runShellCommand(installCmd); err != nil {
 		return fmt.Errorf("failed to install Helm via script: %w", err)

--- a/internal/chart/ui/configuration/wizard.go
+++ b/internal/chart/ui/configuration/wizard.go
@@ -61,3 +61,10 @@ func (w *ConfigurationWizard) ConfigureHelmValuesWithMode(deploymentMode types.D
 
 	return w.configureInteractive(deploymentMode)
 }
+
+// ConfigureHelmValuesWithModeDefaults configures helm values with pre-selected
+// deployment mode using default configuration, skipping all prompts.
+// This is used by bootstrap when --deployment-mode is provided to minimize interaction.
+func (w *ConfigurationWizard) ConfigureHelmValuesWithModeDefaults(deploymentMode types.DeploymentMode) (*types.ChartConfiguration, error) {
+	return w.configureWithDefaults(deploymentMode)
+}

--- a/internal/chart/utils/types/interfaces.go
+++ b/internal/chart/utils/types/interfaces.go
@@ -136,14 +136,16 @@ type StepResult struct {
 
 // InstallationRequest contains all parameters for chart installation
 type InstallationRequest struct {
-	Args           []string
-	Force          bool
-	DryRun         bool
-	Verbose        bool
-	GitHubRepo     string
-	GitHubBranch   string
-	CertDir        string
-	DeploymentMode string       // Deployment mode: "oss-tenant", "saas-tenant", "saas-shared", or empty for interactive
-	NonInteractive bool         // Skip all prompts, use existing helm-values.yaml
-	KubeConfig     *rest.Config // Kubernetes REST config for cluster communication
+	Args              []string
+	Force             bool
+	DryRun            bool
+	Verbose           bool
+	GitHubRepo        string
+	GitHubBranch      string
+	CertDir           string
+	DeploymentMode    string       // Deployment mode: "oss-tenant", "saas-tenant", "saas-shared", or empty for interactive
+	NonInteractive    bool         // Skip all prompts, use existing helm-values.yaml
+	KubeConfig        *rest.Config // Kubernetes REST config for cluster communication
+	SkipPrerequisites bool         // Skip prerequisite checks (already done by caller, e.g. bootstrap preflight)
+	SkipConfigPrompts bool         // Skip config mode selection; auto-use defaults when deployment mode is set
 }

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -763,3 +763,31 @@ func CreateClusterWithPrerequisitesNonInteractive(clusterName string, verbose bo
 	// Create the cluster and return the rest.Config
 	return service.CreateCluster(config)
 }
+
+// CreateClusterSkipPrerequisites creates a cluster without running prerequisite checks.
+// This is used by the bootstrap command which runs its own unified preflight checks.
+// Returns the *rest.Config for the created cluster.
+func CreateClusterSkipPrerequisites(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
+	// Create service directly without using utils to avoid circular import
+	exec := executor.NewRealCommandExecutor(false, verbose) // dryRun = false
+	var service *ClusterService
+	if nonInteractive {
+		service = NewClusterServiceSuppressed(exec)
+	} else {
+		service = NewClusterService(exec)
+	}
+
+	// Build cluster configuration
+	config := models.ClusterConfig{
+		Name:       clusterName,
+		Type:       models.ClusterTypeK3d,
+		K8sVersion: "",
+		NodeCount:  4,
+	}
+	if clusterName == "" {
+		config.Name = "openframe-dev" // default name
+	}
+
+	// Create the cluster and return the rest.Config
+	return service.CreateCluster(config)
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<hr>
<h2>Summary</h2>
<ul>
<li>Add a unified pre-flight checker that validates <strong>all</strong> prerequisites (Docker, kubectl, k3d, Helm, Git, mkcert, memory, certificates) in a single pass before cluster creation, preventing users from waiting for cluster setup only to fail on chart prerequisites</li>
<li>Add <code>--force</code>, <code>--repo</code>, and <code>--branch</code> flags to <code>openframe bootstrap</code> for overriding memory warnings, custom repository URLs, and branch targeting (useful for contributors working on forks)</li>
<li>Add <code>SkipPrerequisites</code> and <code>SkipConfigPrompts</code> fields to <code>InstallationRequest</code> so bootstrap can skip redundant prerequisite and configuration checks after preflight</li>
<li>Fix cross-platform tool installation: Helm on Linux now uses the official install script instead of fragile distro-specific apt/yum/dnf/pacman repo setup; mkcert installs and generates certificates inside WSL2 on Windows; macOS falls back to direct binary download when Homebrew is unavailable</li>
<li>Fix <code>mkcert</code> not found after install by adding <code>~/bin</code> to <code>PATH</code> for the current process in <code>installMkcertLinux</code>, <code>installMkcertMacOS</code>, <code>ensureMkcertInPath</code>, and <code>ForceRegenerate</code></li>
<li>Fix certificates being re-prompted on subsequent runs by checking <code>~/bin/mkcert</code> in <code>isMkcertInstalled()</code> (in addition to <code>$PATH</code>)</li>
<li>Fix <code>--repo</code> override being silently ignored by changing <code>buildConfiguration</code> to only derive the repository URL from deployment mode when no explicit <code>--repo</code> flag is provided</li>
<li>Update README quick-start section with new flags, one-liner examples, and fork/branch usage</li>
</ul>
<h2>Changed files</h2>

File | Change
-- | --
cmd/bootstrap/bootstrap.go | Add --force, --repo, --branch flags
internal/bootstrap/preflight.go | New — unified pre-flight checker for all cluster + chart prerequisites
internal/bootstrap/service.go | Wire preflight, skip redundant checks, pass repo/branch overrides, show logo
internal/chart/prerequisites/certificates/certificates.go | WSL2 support, ~/bin PATH fixes, macOS Homebrew fallback, arch detection
internal/chart/prerequisites/certificates/certificates_test.go | Update tests for WSL2 and macOS fallback changes
internal/chart/prerequisites/helm/helm.go | Replace distro-specific install methods with single installScript()
internal/chart/services/chart_service.go | Handle SkipPrerequisites, SkipConfigPrompts, default config path
internal/chart/ui/configuration/wizard.go | Add ConfigureHelmValuesWithModeDefaults for no-prompt configuration
internal/chart/utils/types/interfaces.go | Add SkipPrerequisites, SkipConfigPrompts to InstallationRequest
internal/cluster/service.go | Add CreateClusterSkipPrerequisites for bootstrap to bypass duplicate checks
README.md | Updated quick-start, new flags, fork/branch examples


<h2>Test plan</h2>
<ul>
<li>[ ] Run <code>openframe bootstrap</code> interactively and verify the unified preflight check runs before cluster creation</li>
<li>[ ] Run <code>openframe bootstrap --deployment-mode=oss-tenant</code> and verify no configuration prompts appear</li>
<li>[ ] Run <code>openframe bootstrap --force</code> on a machine with &lt;24GB RAM and verify it continues past the memory warning</li>
<li>[ ] Run <code>openframe bootstrap --repo=&lt;fork-url&gt; --branch=&lt;branch&gt;</code> and verify the custom repo/branch is used for chart installation</li>
<li>[ ] Verify <code>openframe bootstrap</code> on Linux installs Helm via the official script (not apt repo setup)</li>
<li>[ ] Verify mkcert is found after install without restarting the shell (<code>~/bin</code> PATH fix)</li>
<li>[ ] Verify running bootstrap a second time does not re-prompt for certificate generation</li>
<li>[ ] Run existing unit tests: <code>go test ./internal/chart/prerequisites/certificates/...</code></li>
</ul></body></html><!--EndFragment-->
</body>
</html>