### PR TITLE
fix(argocd): add 3-min cold-start grace before repo-server stuck-detector restarts

### DIFF
--- a/internal/chart/providers/argocd/diagnostics.go
+++ b/internal/chart/providers/argocd/diagnostics.go
@@ -16,6 +16,37 @@ import (
 // repoServerSelector matches the ArgoCD repo-server pods.
 const repoServerSelector = "app.kubernetes.io/name=argocd-repo-server"
 
+// repoServerColdStartGrace is how old the repo-server pod must be before the
+// stuck-detector may restart it. A repo-server younger than this is still
+// warming up (first manifest renders on a cold install take minutes on k3d),
+// and restarting it re-zeroes rendering for every application — manufacturing
+// the very "connection refused" conditions the detector keys on, which then
+// justify the next restart (the cold-start restart carousel).
+const repoServerColdStartGrace = 3 * time.Minute
+
+// repoServerAge returns the age of the youngest repo-server pod. ok is false
+// when the age cannot be determined (no client, list error, no pods) — callers
+// should then fall back to their previous behaviour rather than block recovery.
+func (m *Manager) repoServerAge(ctx context.Context) (age time.Duration, ok bool) {
+	if m.kubeClient == nil {
+		return 0, false
+	}
+	pods, err := m.kubeClient.CoreV1().Pods(ArgoCDNamespace).List(ctx, metav1.ListOptions{LabelSelector: repoServerSelector})
+	if err != nil || len(pods.Items) == 0 {
+		return 0, false
+	}
+	for i := range pods.Items {
+		start := pods.Items[i].Status.StartTime
+		if start == nil {
+			return 0, true // scheduled but not started: youngest possible
+		}
+		if a := time.Since(start.Time); !ok || a < age {
+			age, ok = a, true
+		}
+	}
+	return age, ok
+}
+
 // RepoServerIssue describes a detected problem with the ArgoCD repo-server.
 type RepoServerIssue struct {
 	Type        string // "communication", "resource", "git", "timeout"

--- a/internal/chart/providers/argocd/diagnostics_test.go
+++ b/internal/chart/providers/argocd/diagnostics_test.go
@@ -1,0 +1,65 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func repoServerPod(name string, started time.Time) *corev1.Pod {
+	t := metav1.NewTime(started)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ArgoCDNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": "argocd-repo-server"},
+		},
+		Status: corev1.PodStatus{StartTime: &t},
+	}
+}
+
+func TestRepoServerAge_NoClient(t *testing.T) {
+	m := &Manager{}
+	if _, ok := m.repoServerAge(context.Background()); ok {
+		t.Fatal("expected ok=false without a client")
+	}
+}
+
+func TestRepoServerAge_NoPods(t *testing.T) {
+	m := &Manager{kubeClient: fake.NewSimpleClientset()}
+	if _, ok := m.repoServerAge(context.Background()); ok {
+		t.Fatal("expected ok=false with no repo-server pods")
+	}
+}
+
+func TestRepoServerAge_YoungestPodWins(t *testing.T) {
+	old := repoServerPod("repo-old", time.Now().Add(-30*time.Minute))
+	young := repoServerPod("repo-young", time.Now().Add(-1*time.Minute))
+	m := &Manager{kubeClient: fake.NewSimpleClientset(old, young)}
+
+	age, ok := m.repoServerAge(context.Background())
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if age < 30*time.Second || age > 2*time.Minute {
+		t.Fatalf("expected age of the youngest pod (~1m), got %s", age)
+	}
+	if age >= repoServerColdStartGrace {
+		t.Fatalf("a 1-minute-old repo-server must be within the cold-start grace, got %s", age)
+	}
+}
+
+func TestRepoServerAge_NotYetStarted(t *testing.T) {
+	pod := repoServerPod("repo-pending", time.Now())
+	pod.Status.StartTime = nil
+	m := &Manager{kubeClient: fake.NewSimpleClientset(pod)}
+
+	age, ok := m.repoServerAge(context.Background())
+	if !ok || age != 0 {
+		t.Fatalf("a pod without StartTime should report age 0, ok=true; got %s, %v", age, ok)
+	}
+}

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -65,8 +65,15 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 		// If repo-server has already restarted, proactively restart it to clear any stuck state
 		// This helps CI environments where the pod may have OOM'd during initial setup
 		if initialIssue.Type == "resource" && initialIssue.Recoverable {
-			pterm.Info.Println("Restarting the ArgoCD repo-server to clear the stuck state...")
-			m.triggerRepoServerRecovery(localCtx, "")
+			if age, ok := m.repoServerAge(localCtx); ok && age < repoServerColdStartGrace {
+				// Cold-start grace: a freshly started repo-server produces exactly
+				// these symptoms while it warms up; restarting it only prolongs that.
+				pterm.Info.Printfln("ArgoCD repo-server is only %s old; giving it %s to settle before considering restarts.",
+					age.Round(time.Second), repoServerColdStartGrace)
+			} else {
+				pterm.Info.Println("Restarting the ArgoCD repo-server to clear the stuck state...")
+				m.triggerRepoServerRecovery(localCtx, "")
+			}
 		} else if !initialIssue.Recoverable {
 			pterm.Warning.Println("This is not automatically recoverable — the installation may fail. " +
 				"Check resources with: kubectl describe pods -n argocd -l app.kubernetes.io/component=repo-server")
@@ -467,6 +474,18 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 						// After 2 consecutive checks with repo-server issues, recover.
 						if consecutiveIssues >= 2 && time.Since(lastRepoServerDiagnostic) >= repoServerDiagnosticInterval {
 							lastRepoServerDiagnostic = time.Now()
+
+							// Cold-start grace: never restart a repo-server that is still
+							// warming up — on a fresh install the first manifest renders
+							// legitimately fail with the same "connection refused"/EOF
+							// conditions this detector keys on, and each restart re-zeroes
+							// rendering for every app, restarting the carousel. This also
+							// spaces successive recovery attempts at least the grace apart.
+							if age, ok := m.repoServerAge(localCtx); ok && age < repoServerColdStartGrace {
+								pterm.Info.Printfln("ArgoCD repo-server is only %s old; waiting for it to settle (%s grace) before considering a restart.",
+									age.Round(time.Second), repoServerColdStartGrace)
+								break
+							}
 
 							if repoServerRecoveryAttempts < maxRepoServerRecoveryAttempts {
 								repoServerRecoveryAttempts++


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Argo CD application recovery during repo-server startup.
  - Added a brief grace period for newly started repo-server pods, preventing premature restarts while they warm up.
  - Preserved recovery behavior for repo-server issues that continue beyond the startup period.
  - Improved handling of repo-server pods that have been scheduled but not yet started.

- **Tests**
  - Added coverage for missing clients, unavailable pods, pod age selection, and startup-time handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->