### PR TITLE
chore(cluster): reintroduce provider factory and de-hardcode k3d seams

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -46,6 +46,12 @@ Examples:
 			if cmd.Use != "cluster" {
 				ui.ShowLogoWithContext(cmd.Context())
 			}
+			// create runs its own type-aware gate after the cluster type is known
+			// (a cloud cluster must not demand Docker/k3d); the other subcommands
+			// are k3d-scoped, so the k3d gate stays here.
+			if cmd.Name() == "create" {
+				return nil
+			}
 			return prerequisites.CheckPrerequisites()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	"github.com/spf13/cobra"
@@ -128,6 +129,14 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 		if globalFlags.Create.DryRun {
 			return nil
 		}
+	}
+
+	// Type-aware prerequisite gate: runs after the type is known (wizard or
+	// flags), so only the tools the chosen backend needs are demanded. It sits
+	// after the dry-run return on purpose — the gate may INSTALL tools, and
+	// dry-run must not mutate the system.
+	if err := prerequisites.CheckForClusterType(config.Type); err != nil {
+		return err
 	}
 
 	// Execute cluster creation through service layer

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
@@ -69,6 +70,29 @@ func TestRunCreateCluster_DryRunDefaultsNameWhenNoArgs(t *testing.T) {
 	// No args → the default "openframe-dev" name branch, then dry-run nil.
 	if err := runCreateCluster(cmd, nil); err != nil {
 		t.Fatalf("dry-run with default name should return nil, got %v", err)
+	}
+}
+
+func TestRunCreateCluster_CloudTypeFailsWithProviderNotFound(t *testing.T) {
+	for _, clusterType := range []string{"gke", "eks"} {
+		t.Run(clusterType, func(t *testing.T) {
+			setupCreate(t)
+			cmd := getCreateCmd()
+			gf := utils.GetGlobalFlags()
+			gf.Create.SkipWizard = true
+			gf.Create.ClusterType = clusterType
+
+			// The type passes flag validation (recognized) and the local-tool
+			// prerequisite gate (cloud types skip it), then fails at the provider
+			// factory — no cloud backend is implemented yet.
+			err := runCreateCluster(cmd, []string{"cloud-cluster"})
+			if err == nil {
+				t.Fatal("expected ErrProviderNotFound for a cloud cluster type")
+			}
+			if !strings.Contains(err.Error(), "no provider available for cluster type") {
+				t.Fatalf("expected provider-not-found error, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ for CLI design with wizard-style interactive prompts.
 
 Key Features:
   - Interactive Wizard - Step-by-step guided setup
-  - Cluster Management - K3d, Kind, and cloud provider support
+  - Cluster Management - local K3d clusters (cloud providers planned)
   - Helm Integration - App-of-Apps pattern with ArgoCD
   - Prerequisite Checking - Validates tools before running
 

--- a/internal/cluster/models/cluster.go
+++ b/internal/cluster/models/cluster.go
@@ -17,6 +17,21 @@ type ClusterConfig struct {
 	Type       ClusterType `json:"type"`
 	NodeCount  int         `json:"node_count"`
 	K8sVersion string      `json:"k8s_version"`
+	// Cloud carries the settings that only make sense for managed cloud
+	// clusters (GKE/EKS). Nil for local clusters; the k3d backend rejects a
+	// config that sets it.
+	Cloud *CloudConfig `json:"cloud,omitempty"`
+}
+
+// CloudConfig holds the provider-agnostic knobs for a managed cloud cluster.
+type CloudConfig struct {
+	Region      string `json:"region"`
+	Project     string `json:"project,omitempty"` // GCP project
+	Profile     string `json:"profile,omitempty"` // AWS profile
+	MachineType string `json:"machine_type,omitempty"`
+	MinNodes    int    `json:"min_nodes,omitempty"`
+	MaxNodes    int    `json:"max_nodes,omitempty"`
+	Spot        bool   `json:"spot,omitempty"`
 }
 
 // ClusterInfo represents information about a cluster
@@ -40,22 +55,4 @@ type NodeInfo struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
 	Role   string `json:"role"`
-}
-
-// ProviderOptions contains provider-specific options
-type ProviderOptions struct {
-	K3d     *K3dOptions `json:"k3d,omitempty"`
-	GKE     *GKEOptions `json:"gke,omitempty"`
-	Verbose bool        `json:"verbose,omitempty"`
-}
-
-// K3dOptions contains k3d-specific options
-type K3dOptions struct {
-	PortMappings []string `json:"port_mappings,omitempty"`
-}
-
-// GKEOptions contains GKE-specific options
-type GKEOptions struct {
-	Zone    string `json:"zone"`
-	Project string `json:"project"`
 }

--- a/internal/cluster/models/cluster_test.go
+++ b/internal/cluster/models/cluster_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -177,84 +178,29 @@ func TestNodeInfo(t *testing.T) {
 	})
 }
 
-func TestProviderOptions(t *testing.T) {
-	t.Run("creates provider options with K3d options", func(t *testing.T) {
-		options := ProviderOptions{
-			K3d: &K3dOptions{
-				PortMappings: []string{"8080:80@loadbalancer", "8443:443@loadbalancer"},
-			},
-			Verbose: true,
+func TestCloudConfig(t *testing.T) {
+	t.Run("cluster config without cloud settings has nil Cloud", func(t *testing.T) {
+		var config ClusterConfig
+
+		assert.Nil(t, config.Cloud)
+	})
+
+	t.Run("holds provider-agnostic cloud settings", func(t *testing.T) {
+		cloud := CloudConfig{
+			Region:      "us-east-1",
+			Profile:     "default",
+			MachineType: "m6i.large",
+			MinNodes:    1,
+			MaxNodes:    5,
+			Spot:        true,
 		}
 
-		assert.NotNil(t, options.K3d)
-		assert.Equal(t, []string{"8080:80@loadbalancer", "8443:443@loadbalancer"}, options.K3d.PortMappings)
-		assert.True(t, options.Verbose)
-		assert.Nil(t, options.GKE)
-	})
-
-	t.Run("creates provider options with GKE options", func(t *testing.T) {
-		options := ProviderOptions{
-			GKE: &GKEOptions{
-				Zone:    "us-central1-a",
-				Project: "my-project",
-			},
-		}
-
-		assert.NotNil(t, options.GKE)
-		assert.Equal(t, "us-central1-a", options.GKE.Zone)
-		assert.Equal(t, "my-project", options.GKE.Project)
-		assert.Nil(t, options.K3d)
-		assert.False(t, options.Verbose)
-	})
-
-	t.Run("creates empty provider options", func(t *testing.T) {
-		options := ProviderOptions{}
-
-		assert.Nil(t, options.K3d)
-		assert.Nil(t, options.GKE)
-		assert.False(t, options.Verbose)
-	})
-}
-
-func TestK3dOptions(t *testing.T) {
-	t.Run("creates K3d options with port mappings", func(t *testing.T) {
-		options := K3dOptions{
-			PortMappings: []string{
-				"8080:80@loadbalancer",
-				"8443:443@loadbalancer",
-				"6550:6443@server:0",
-			},
-		}
-
-		assert.Len(t, options.PortMappings, 3)
-		assert.Contains(t, options.PortMappings, "8080:80@loadbalancer")
-		assert.Contains(t, options.PortMappings, "8443:443@loadbalancer")
-		assert.Contains(t, options.PortMappings, "6550:6443@server:0")
-	})
-
-	t.Run("creates empty K3d options", func(t *testing.T) {
-		options := K3dOptions{}
-
-		assert.Empty(t, options.PortMappings)
-	})
-}
-
-func TestGKEOptions(t *testing.T) {
-	t.Run("creates GKE options with zone and project", func(t *testing.T) {
-		options := GKEOptions{
-			Zone:    "europe-west1-b",
-			Project: "my-gcp-project",
-		}
-
-		assert.Equal(t, "europe-west1-b", options.Zone)
-		assert.Equal(t, "my-gcp-project", options.Project)
-	})
-
-	t.Run("creates empty GKE options", func(t *testing.T) {
-		options := GKEOptions{}
-
-		assert.Empty(t, options.Zone)
-		assert.Empty(t, options.Project)
+		assert.Equal(t, "us-east-1", cloud.Region)
+		assert.Equal(t, "default", cloud.Profile)
+		assert.Equal(t, "m6i.large", cloud.MachineType)
+		assert.Equal(t, 1, cloud.MinNodes)
+		assert.Equal(t, 5, cloud.MaxNodes)
+		assert.True(t, cloud.Spot)
 	})
 }
 
@@ -289,16 +235,25 @@ func TestJSONSerialization(t *testing.T) {
 		assert.Equal(t, 5, info.NodeCount)
 	})
 
-	t.Run("provider options serialization", func(t *testing.T) {
-		options := ProviderOptions{
-			K3d: &K3dOptions{
-				PortMappings: []string{"8080:80@loadbalancer"},
+	t.Run("cloud config round-trips through JSON and is omitted when nil", func(t *testing.T) {
+		config := ClusterConfig{
+			Name: "cloud-cluster",
+			Type: ClusterTypeEKS,
+			Cloud: &CloudConfig{
+				Region:   "eu-west-1",
+				MaxNodes: 4,
 			},
-			Verbose: true,
 		}
 
-		// Basic validation that struct tags are correct
-		assert.NotNil(t, options.K3d)
-		assert.True(t, options.Verbose)
+		data, err := json.Marshal(config)
+		assert.NoError(t, err)
+
+		var decoded ClusterConfig
+		assert.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, config, decoded)
+
+		local, err := json.Marshal(ClusterConfig{Name: "local", Type: ClusterTypeK3d})
+		assert.NoError(t, err)
+		assert.NotContains(t, string(local), "cloud")
 	})
 }

--- a/internal/cluster/models/flags.go
+++ b/internal/cluster/models/flags.go
@@ -56,7 +56,7 @@ func AddGlobalFlags(cmd *cobra.Command, global *GlobalFlags) {
 
 // AddCreateFlags adds create-specific flags to a command
 func AddCreateFlags(cmd *cobra.Command, flags *CreateFlags) {
-	cmd.Flags().StringVarP(&flags.ClusterType, "type", "t", "", "Cluster type (k3d, gke)")
+	cmd.Flags().StringVarP(&flags.ClusterType, "type", "t", "", "Cluster type (k3d)")
 	cmd.Flags().IntVarP(&flags.NodeCount, "nodes", "n", 3, "Number of nodes (default 3)")
 	cmd.Flags().StringVar(&flags.K8sVersion, "version", "", "Kubernetes version")
 	cmd.Flags().BoolVar(&flags.SkipWizard, "skip-wizard", false, "Skip interactive wizard")
@@ -129,6 +129,16 @@ func ValidateGlobalFlags(globalFlags *GlobalFlags) error {
 func ValidateCreateFlags(flags *CreateFlags) error {
 	if err := ValidateGlobalFlags(&flags.GlobalFlags); err != nil {
 		return err
+	}
+
+	// Reject unknown --type values up front. Recognized-but-unimplemented cloud
+	// types (gke, eks) pass here and fail later with ErrProviderNotFound at the
+	// provider factory, so the two cases stay distinguishable.
+	switch ClusterType(flags.ClusterType) {
+	case "", ClusterTypeK3d, ClusterTypeGKE, ClusterTypeEKS:
+		// known
+	default:
+		return fmt.Errorf("unknown cluster type '%s' (supported: k3d)", flags.ClusterType)
 	}
 
 	// Validate node count - this validation is now handled at command level

--- a/internal/cluster/models/flags_test.go
+++ b/internal/cluster/models/flags_test.go
@@ -286,6 +286,23 @@ func TestFlagValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "node count must be at least 1")
 	})
 
+	t.Run("accepts empty and recognized cluster types", func(t *testing.T) {
+		for _, clusterType := range []string{"", "k3d", "gke", "eks"} {
+			flags := &CreateFlags{ClusterType: clusterType, NodeCount: 3}
+
+			err := ValidateCreateFlags(flags)
+			assert.NoError(t, err, "type %q should pass flag validation", clusterType)
+		}
+	})
+
+	t.Run("rejects unknown cluster type", func(t *testing.T) {
+		flags := &CreateFlags{ClusterType: "minikube", NodeCount: 3}
+
+		err := ValidateCreateFlags(flags)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown cluster type 'minikube'")
+	})
+
 	t.Run("validates list flags", func(t *testing.T) {
 		flags := &ListFlags{Quiet: true}
 

--- a/internal/cluster/prerequisites/checker.go
+++ b/internal/cluster/prerequisites/checker.go
@@ -1,6 +1,7 @@
 package prerequisites
 
 import (
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/docker"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/helm"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/k3d"
@@ -65,4 +66,18 @@ func (pc *PrerequisiteChecker) CheckAll() (bool, []string) {
 func CheckPrerequisites() error {
 	// A CI environment or a non-terminal stdin must not hit an interactive prompt.
 	return NewInstaller().CheckAndInstallNonInteractive(ui.IsNonInteractive())
+}
+
+// CheckForClusterType runs the prerequisite gate for the given cluster type.
+// Docker/k3d/helm are only required for local k3d clusters; cloud types bring
+// their own prerequisite sets with their backends (none implemented yet), so
+// they pass through and fail later at the provider factory instead of
+// demanding tools they will never use.
+func CheckForClusterType(clusterType models.ClusterType) error {
+	switch clusterType {
+	case models.ClusterTypeK3d, "":
+		return CheckPrerequisites()
+	default:
+		return nil
+	}
 }

--- a/internal/cluster/prerequisites/checker_test.go
+++ b/internal/cluster/prerequisites/checker_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/docker"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/helm"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/k3d"
@@ -80,6 +81,16 @@ func containsAny(str string, substrings []string) bool {
 		}
 	}
 	return false
+}
+
+func TestCheckForClusterType_CloudTypesSkipLocalGate(t *testing.T) {
+	// The Docker/k3d/helm gate is for local clusters only; cloud types must
+	// pass through regardless of what is installed on this machine.
+	for _, clusterType := range []models.ClusterType{models.ClusterTypeGKE, models.ClusterTypeEKS} {
+		if err := CheckForClusterType(clusterType); err != nil {
+			t.Errorf("CheckForClusterType(%s) should not require local tools: %v", clusterType, err)
+		}
+	}
 }
 
 func TestCheckAllWithMissingTools(t *testing.T) {

--- a/internal/cluster/provider/factory.go
+++ b/internal/cluster/provider/factory.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/k3d"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+)
+
+// New returns the Provider for the given cluster type. An empty type defaults
+// to k3d (the local development default). GKE/EKS are recognized types whose
+// backends are not implemented yet, so they return ErrProviderNotFound; an
+// unrecognized type is a configuration error.
+func New(clusterType models.ClusterType, exec executor.CommandExecutor) (Provider, error) {
+	switch clusterType {
+	case models.ClusterTypeK3d, "":
+		return k3d.CreateClusterManagerWithExecutor(exec), nil
+	case models.ClusterTypeGKE, models.ClusterTypeEKS:
+		return nil, models.NewProviderNotFoundError(clusterType)
+	default:
+		return nil, models.NewInvalidConfigError("type", clusterType, "unknown cluster type")
+	}
+}

--- a/internal/cluster/provider/factory_test.go
+++ b/internal/cluster/provider/factory_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	exec := executor.NewMockCommandExecutor()
+
+	t.Run("k3d returns a provider", func(t *testing.T) {
+		p, err := New(models.ClusterTypeK3d, exec)
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+
+	t.Run("empty type defaults to k3d", func(t *testing.T) {
+		p, err := New("", exec)
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+
+	t.Run("recognized cloud types return ErrProviderNotFound", func(t *testing.T) {
+		for _, clusterType := range []models.ClusterType{models.ClusterTypeGKE, models.ClusterTypeEKS} {
+			p, err := New(clusterType, exec)
+			assert.Nil(t, p)
+			var notFound models.ErrProviderNotFound
+			assert.True(t, errors.As(err, &notFound), "expected ErrProviderNotFound for %s, got %v", clusterType, err)
+			assert.Equal(t, clusterType, notFound.ClusterType)
+		}
+	})
+
+	t.Run("unknown type is a config error", func(t *testing.T) {
+		p, err := New("minikube", exec)
+		assert.Nil(t, p)
+		var invalid models.ErrInvalidClusterConfig
+		assert.True(t, errors.As(err, &invalid), "expected ErrInvalidClusterConfig, got %v", err)
+	})
+}

--- a/internal/cluster/provider/provider.go
+++ b/internal/cluster/provider/provider.go
@@ -1,9 +1,10 @@
 // Package provider defines the unified cluster-provider abstraction.
 //
 // A Provider creates and manages Kubernetes clusters. Today only k3d (local) is
-// implemented; cloud providers (GKE, EKS) are placeholders that return a
-// friendly "coming soon" error. New backends implement the same Provider
-// interface, so the rest of the CLI never needs to know which backend is used.
+// implemented; for the recognized cloud types (GKE, EKS) the factory returns
+// ErrProviderNotFound until their backends land. New backends implement the
+// same Provider interface, so the rest of the CLI never needs to know which
+// backend is used.
 package provider
 
 import (
@@ -40,10 +41,7 @@ type Provider interface {
 
 // Compile-time assertion that the k3d manager satisfies Provider.
 //
-// NOTE: there is deliberately NO factory here. The old New(clusterType,
-// target, ...) "single seam" was never called from production — every
-// constructor hard-coded the k3d manager, so the factory was decorative
-// (audit B7). The interface itself is the real seam: it is what
-// ClusterService depends on and what tests mock. When a second backend
-// (GKE/EKS) actually lands, reintroduce a factory alongside its first caller.
+// Backends are selected through New (factory.go). The old decorative factory
+// was removed in audit B7 because nothing called it; this one is real —
+// ClusterService resolves its backend through it, keyed on ClusterConfig.Type.
 var _ Provider = (*k3d.K3dManager)(nil)

--- a/internal/cluster/providers/k3d/manager.go
+++ b/internal/cluster/providers/k3d/manager.go
@@ -382,6 +382,9 @@ func (m *K3dManager) validateClusterConfig(config models.ClusterConfig) error {
 	if config.NodeCount < 1 {
 		return models.NewInvalidConfigError("nodeCount", config.NodeCount, "node count must be at least 1")
 	}
+	if config.Cloud != nil {
+		return models.NewInvalidConfigError("cloud", config.Cloud, "cloud settings are not valid for k3d clusters")
+	}
 	return nil
 }
 

--- a/internal/cluster/providers/k3d/manager_test.go
+++ b/internal/cluster/providers/k3d/manager_test.go
@@ -199,6 +199,16 @@ func TestK3dManager_CreateCluster(t *testing.T) {
 			expectedError: "node count must be at least 1",
 		},
 		{
+			name: "cloud settings rejected for k3d",
+			config: models.ClusterConfig{
+				Name:      "test-cluster",
+				Type:      models.ClusterTypeK3d,
+				NodeCount: 3,
+				Cloud:     &models.CloudConfig{Region: "us-east-1"},
+			},
+			expectedError: "cloud settings are not valid for k3d clusters",
+		},
+		{
 			name: "k3d command fails",
 			config: models.ClusterConfig{
 				Name:      "test-cluster",

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -11,11 +11,9 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/provider"
-	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/k3d"
 	uiCluster "github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/k8s"
 	"github.com/flamingo-stack/openframe-cli/internal/platform"
-	sharedconfig "github.com/flamingo-stack/openframe-cli/internal/shared/config"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/ui/spinner"
@@ -73,7 +71,7 @@ func isTerminalEnvironment() bool {
 
 // NewClusterService creates a new cluster service with default configuration
 func NewClusterService(exec executor.CommandExecutor) *ClusterService {
-	manager := k3d.CreateClusterManagerWithExecutor(exec)
+	manager, _ := provider.New(models.ClusterTypeK3d, exec) // k3d never fails to construct
 	return &ClusterService{
 		manager:    manager,
 		executor:   exec,
@@ -83,7 +81,7 @@ func NewClusterService(exec executor.CommandExecutor) *ClusterService {
 
 // NewClusterServiceSuppressed creates a cluster service with UI suppression
 func NewClusterServiceSuppressed(exec executor.CommandExecutor) *ClusterService {
-	manager := k3d.CreateClusterManagerWithExecutor(exec)
+	manager, _ := provider.New(models.ClusterTypeK3d, exec) // k3d never fails to construct
 	return &ClusterService{
 		manager:    manager,
 		executor:   exec,
@@ -91,11 +89,29 @@ func NewClusterServiceSuppressed(exec executor.CommandExecutor) *ClusterService 
 	}
 }
 
+// providerFor resolves the backend for a cluster type. The k3d manager is the
+// service default (list/status/cleanup are k3d-scoped until cloud backends
+// land); anything else goes through the factory, which today yields
+// ErrProviderNotFound for the recognized cloud types.
+func (s *ClusterService) providerFor(clusterType models.ClusterType) (provider.Provider, error) {
+	if clusterType == models.ClusterTypeK3d || clusterType == "" {
+		return s.manager, nil
+	}
+	return provider.New(clusterType, s.executor)
+}
+
 // CreateCluster handles cluster creation operations
 // Returns the *rest.Config for the created cluster that can be used to interact with it
 func (s *ClusterService) CreateCluster(ctx context.Context, config models.ClusterConfig) (*rest.Config, error) {
+	// Resolve the backend first: an unsupported type must fail here, before any
+	// k3d-specific existence checks run.
+	mgr, err := s.providerFor(config.Type)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check if cluster already exists
-	if existingInfo, err := s.manager.GetClusterStatus(ctx, config.Name); err == nil {
+	if existingInfo, err := mgr.GetClusterStatus(ctx, config.Name); err == nil {
 		// Cluster already exists - show friendly message
 
 		// Show warning for existing cluster
@@ -130,7 +146,7 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 		}
 
 		// Return the rest.Config for the existing cluster
-		restConfig, err := s.manager.GetRestConfig(ctx, config.Name)
+		restConfig, err := mgr.GetRestConfig(ctx, config.Name)
 		if err != nil {
 			return nil, fmt.Errorf("cluster exists but failed to get REST config: %w", err)
 		}
@@ -147,7 +163,7 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 		pterm.Info.Printf("Creating %s cluster '%s'...\n", config.Type, config.Name)
 	}
 
-	restConfig, err := s.manager.CreateCluster(ctx, config)
+	restConfig, err := mgr.CreateCluster(ctx, config)
 	if err != nil {
 		if sp != nil {
 			sp.Fail(fmt.Sprintf("Failed to create cluster '%s'", config.Name))
@@ -162,7 +178,7 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 	}
 
 	// Get and display cluster status
-	if clusterInfo, statusErr := s.manager.GetClusterStatus(ctx, config.Name); statusErr == nil {
+	if clusterInfo, statusErr := mgr.GetClusterStatus(ctx, config.Name); statusErr == nil {
 		s.displayClusterCreationSummary(clusterInfo)
 	}
 
@@ -174,6 +190,11 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 
 // DeleteCluster handles cluster deletion business logic
 func (s *ClusterService) DeleteCluster(ctx context.Context, name string, clusterType models.ClusterType, force bool) error {
+	mgr, err := s.providerFor(clusterType)
+	if err != nil {
+		return err
+	}
+
 	// Show deletion progress
 	var sp *spinner.Spinner
 	if !s.suppressUI {
@@ -183,7 +204,7 @@ func (s *ClusterService) DeleteCluster(ctx context.Context, name string, cluster
 		pterm.Info.Printf("Deleting %s cluster '%s'...\n", clusterType, name)
 	}
 
-	err := s.manager.DeleteCluster(ctx, name, clusterType, force)
+	err = mgr.DeleteCluster(ctx, name, clusterType, force)
 	if err != nil {
 		if sp != nil {
 			sp.Fail(fmt.Sprintf("Failed to delete cluster '%s'", name))
@@ -434,11 +455,14 @@ func (s *ClusterService) cleanupKubernetesResources(ctx context.Context, cluster
 		return 0, err
 	}
 
+	// TLS policy is the provider's mint-time decision: k3d marks its local
+	// rest.Config insecure itself (verify.go), and a future cloud provider's
+	// config must NOT be downgraded here.
 	restConfig, err := s.manager.GetRestConfig(ctx, clusterName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get cluster config for cleanup: %w", err)
 	}
-	client, err := kubernetes.NewForConfig(sharedconfig.ApplyInsecureTLSConfig(restConfig))
+	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/internal/cluster/service_test.go
+++ b/internal/cluster/service_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
@@ -56,6 +57,42 @@ func TestClusterService_CreateCluster(t *testing.T) {
 	// With mock executor, error can occur if cluster already exists or kubeconfig issues
 	// We just verify it doesn't panic
 	_ = err
+}
+
+func TestClusterService_CreateCluster_CloudTypeFailsBeforeAnyCommand(t *testing.T) {
+	for _, clusterType := range []models.ClusterType{models.ClusterTypeGKE, models.ClusterTypeEKS} {
+		mock := executor.NewMockCommandExecutor()
+		service := NewClusterService(mock)
+
+		_, err := service.CreateCluster(context.Background(), models.ClusterConfig{
+			Name:      "cloud-cluster",
+			Type:      clusterType,
+			NodeCount: 1,
+		})
+
+		var notFound models.ErrProviderNotFound
+		if !errors.As(err, &notFound) {
+			t.Fatalf("expected ErrProviderNotFound for %s, got %v", clusterType, err)
+		}
+		if mock.GetCommandCount() != 0 {
+			t.Errorf("no commands should run for unsupported type %s, got: %v", clusterType, mock.GetExecutedCommands())
+		}
+	}
+}
+
+func TestClusterService_DeleteCluster_CloudTypeFailsBeforeAnyCommand(t *testing.T) {
+	mock := executor.NewMockCommandExecutor()
+	service := NewClusterService(mock)
+
+	err := service.DeleteCluster(context.Background(), "cloud-cluster", models.ClusterTypeEKS, false)
+
+	var notFound models.ErrProviderNotFound
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected ErrProviderNotFound, got %v", err)
+	}
+	if mock.GetCommandCount() != 0 {
+		t.Errorf("no commands should run for unsupported type, got: %v", mock.GetExecutedCommands())
+	}
 }
 
 func TestClusterService_DeleteCluster(t *testing.T) {

--- a/internal/cluster/types_test.go
+++ b/internal/cluster/types_test.go
@@ -156,21 +156,6 @@ func TestNodeInfo(t *testing.T) {
 	})
 }
 
-func TestProviderOptions(t *testing.T) {
-	t.Run("can create and use provider options", func(t *testing.T) {
-		options := models.ProviderOptions{
-			K3d: &models.K3dOptions{
-				PortMappings: []string{"8080:80@loadbalancer", "8443:443@loadbalancer"},
-			},
-			Verbose: true,
-		}
-
-		assert.NotNil(t, options.K3d)
-		assert.Equal(t, []string{"8080:80@loadbalancer", "8443:443@loadbalancer"}, options.K3d.PortMappings)
-		assert.True(t, options.Verbose)
-	})
-}
-
 func TestErrorTypes(t *testing.T) {
 	t.Run("cluster not found error", func(t *testing.T) {
 		err := models.NewClusterNotFoundError("test-cluster")

--- a/internal/cluster/ui/prompts.go
+++ b/internal/cluster/ui/prompts.go
@@ -13,7 +13,6 @@ type ClusterInfo = models.ClusterInfo
 // Re-export domain constants for UI convenience
 const (
 	ClusterTypeK3d = models.ClusterTypeK3d
-	ClusterTypeGKE = models.ClusterTypeGKE
 )
 
 // UI should not depend on business logic interfaces

--- a/internal/cluster/ui/prompts_test.go
+++ b/internal/cluster/ui/prompts_test.go
@@ -101,6 +101,5 @@ func TestValidationLogic(t *testing.T) {
 func TestConstants(t *testing.T) {
 	t.Run("cluster type constants are correctly defined", func(t *testing.T) {
 		assert.Equal(t, string(ClusterTypeK3d), "k3d")
-		assert.Equal(t, string(ClusterTypeGKE), "gke")
 	})
 }

--- a/internal/cluster/ui/wizard.go
+++ b/internal/cluster/ui/wizard.go
@@ -56,28 +56,24 @@ func (w *ConfigWizard) Run() (ClusterConfig, error) {
 	}
 	w.config.Name = name
 
-	// Step 2: Cluster type
-	clusterType, err := steps.PromptClusterType()
-	if err != nil {
-		return ClusterConfig{}, err
-	}
-	w.config.Type = clusterType
+	// Cluster type is not prompted: k3d is the only implemented backend. When a
+	// cloud backend lands, reintroduce a type step here with real options.
 
-	// Step 3: Node count
+	// Step 2: Node count
 	nodeCount, err := steps.PromptNodeCount(w.config.NodeCount)
 	if err != nil {
 		return ClusterConfig{}, err
 	}
 	w.config.NodeCount = nodeCount
 
-	// Step 4: Kubernetes version
+	// Step 3: Kubernetes version
 	k8sVersion, err := steps.PromptK8sVersion()
 	if err != nil {
 		return ClusterConfig{}, err
 	}
 	w.config.K8sVersion = k8sVersion
 
-	// Step 5: Confirmation
+	// Step 4: Confirmation
 	domainConfig := models.ClusterConfig{
 		Name:       w.config.Name,
 		Type:       w.config.Type,

--- a/internal/cluster/ui/wizard_steps.go
+++ b/internal/cluster/ui/wizard_steps.go
@@ -41,34 +41,6 @@ func (ws *WizardSteps) PromptClusterName(defaultName string) (string, error) {
 	return strings.TrimSpace(result), nil
 }
 
-// PromptClusterType prompts for cluster type selection
-func (ws *WizardSteps) PromptClusterType() (models.ClusterType, error) {
-	prompt := promptui.Select{
-		Label: "Cluster Type",
-		Items: []string{"k3d (Recommended for local development)", "gke (Google Kubernetes Engine - Coming Soon)"},
-		Templates: &promptui.SelectTemplates{
-			Label:    "{{ . }}:",
-			Active:   "→ {{ . | cyan }}",
-			Inactive: "  {{ . }}",
-			Selected: "{{ . | green }}",
-		},
-	}
-
-	idx, _, err := prompt.Run()
-	if err != nil {
-		return "", err
-	}
-
-	switch idx {
-	case 0:
-		return models.ClusterTypeK3d, nil
-	case 1:
-		return models.ClusterTypeGKE, nil
-	default:
-		return models.ClusterTypeK3d, nil
-	}
-}
-
 // PromptNodeCount prompts for number of worker nodes
 func (ws *WizardSteps) PromptNodeCount(defaultCount int) (int, error) {
 	prompt := promptui.Prompt{

--- a/internal/cluster/ui/wizard_steps_test.go
+++ b/internal/cluster/ui/wizard_steps_test.go
@@ -12,15 +12,6 @@ func TestWizardSteps(t *testing.T) {
 	assert.NotNil(t, steps, "NewWizardSteps should return a non-nil instance")
 }
 
-func TestWizardSteps_PromptClusterType(t *testing.T) {
-	steps := NewWizardSteps()
-
-	t.Run("should have cluster type prompt", func(t *testing.T) {
-		// We can't easily test the interactive part, but we can test the method exists
-		assert.NotNil(t, steps.PromptClusterType)
-	})
-}
-
 func TestWizardSteps_PromptK8sVersion(t *testing.T) {
 	steps := NewWizardSteps()
 

--- a/internal/cluster/ui/wizard_test.go
+++ b/internal/cluster/ui/wizard_test.go
@@ -40,7 +40,6 @@ func TestClusterConfig(t *testing.T) {
 			clusterType ClusterType
 		}{
 			{"k3d cluster", ClusterTypeK3d},
-			{"gke cluster", ClusterTypeGKE},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
Phase 0 of cloud-provider support (EKS/GKE via Terraform, see design doc):
- provider.New(type) factory; ClusterService create/delete dispatch on ClusterConfig.Type and fail with typed ErrProviderNotFound pre-k3d
- ClusterConfig.Cloud (*CloudConfig) seam; drop dead ProviderOptions
- remove wizard "gke Coming Soon" step that crashed at runtime; honest --type/root help; reject unknown --type values at flag validation
- type-aware prerequisite gate: create checks tools after type is known (after dry-run exit — the gate may install tools); k3d-only commands keep the persistent gate
- insecure TLS is now solely the k3d provider's mint-time decision