### PR TITLE
feat(cluster): cloud UX polish — plan preview, progress, guarded destroy

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -1,13 +1,18 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/provider"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +67,44 @@ Examples:
 	}
 
 	return createCmd
+}
+
+// planPreviewFn is the cloud dry-run implementation. A package variable so
+// cmd-layer tests can stub it out: the real one shells out to terraform,
+// which unit tests must never do.
+var planPreviewFn = cloudPlanPreview
+
+// cloudPlanPreview runs a real terraform plan for a cloud config and prints
+// the resource footprint. Terraform not being installed is a soft skip — the
+// prerequisite gate only runs on a real create, and a dry-run must not
+// install anything.
+func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
+	if _, err := terraform.FindTerraform(); err != nil {
+		pterm.Info.Println("terraform is not installed — skipping the plan preview (it installs automatically on a real create)")
+		return nil
+	}
+
+	exec := executor.NewRealCommandExecutor(false, utils.GetGlobalFlags().Global.Verbose)
+	p, err := provider.New(config.Type, exec)
+	if err != nil {
+		return err
+	}
+	planner, ok := p.(provider.Planner)
+	if !ok {
+		return nil
+	}
+
+	pterm.Info.Printf("Computing terraform plan for %s cluster '%s'...\n", config.Type, config.Name)
+	summary, err := planner.PlanCluster(ctx, config)
+	if err != nil {
+		return err
+	}
+	if !summary.HasChanges() {
+		pterm.Success.Println("Plan: no changes — the cluster already matches this configuration")
+		return nil
+	}
+	pterm.Success.Printf("Plan: %d to add, %d to change, %d to destroy\n", summary.Add, summary.Change, summary.Destroy)
+	return nil
 }
 
 func runCreateCluster(cmd *cobra.Command, args []string) error {
@@ -130,13 +173,14 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 		if config.Type == models.ClusterTypeEKS || config.Type == models.ClusterTypeGKE {
 			cf := globalFlags.Create
 			config.Cloud = &models.CloudConfig{
-				Region:      cf.Region,
-				Profile:     cf.Profile,
-				Project:     cf.Project,
-				MachineType: cf.MachineType,
-				MinNodes:    cf.MinNodes,
-				MaxNodes:    cf.MaxNodes,
-				Spot:        cf.Spot,
+				Region:        cf.Region,
+				Profile:       cf.Profile,
+				Project:       cf.Project,
+				MachineType:   cf.MachineType,
+				MinNodes:      cf.MinNodes,
+				MaxNodes:      cf.MaxNodes,
+				Spot:          cf.Spot,
+				BackendConfig: cf.BackendConfig,
 			}
 		}
 	}
@@ -146,8 +190,12 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 		operationsUI := ui.NewOperationsUI()
 		operationsUI.ShowConfigurationSummary(config, globalFlags.Create.DryRun, globalFlags.Create.SkipWizard)
 
-		// If dry-run, don't actually create the cluster
+		// If dry-run, don't actually create the cluster. For cloud types the
+		// dry-run is a real terraform plan of what create would provision.
 		if globalFlags.Create.DryRun {
+			if config.Type == models.ClusterTypeEKS || config.Type == models.ClusterTypeGKE {
+				return planPreviewFn(cmd.Context(), config)
+			}
 			return nil
 		}
 	}

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
@@ -72,10 +74,19 @@ func TestRunCreateCluster_DryRunDefaultsNameWhenNoArgs(t *testing.T) {
 	}
 }
 
-func TestRunCreateCluster_CloudDryRunShowsSummaryAndExits(t *testing.T) {
+func TestRunCreateCluster_CloudDryRunRunsPlanPreview(t *testing.T) {
 	for _, clusterType := range []string{"eks", "gke"} {
 		t.Run(clusterType, func(t *testing.T) {
 			setupCreate(t)
+			// Stub the preview: the real one shells out to terraform.
+			var previewed *models.ClusterConfig
+			orig := planPreviewFn
+			planPreviewFn = func(ctx context.Context, config models.ClusterConfig) error {
+				previewed = &config
+				return nil
+			}
+			t.Cleanup(func() { planPreviewFn = orig })
+
 			cmd := getCreateCmd()
 			gf := utils.GetGlobalFlags()
 			gf.Create.SkipWizard = true
@@ -84,13 +95,39 @@ func TestRunCreateCluster_CloudDryRunShowsSummaryAndExits(t *testing.T) {
 			gf.Create.Region = "us-east-1"
 			gf.Create.Project = "my-project"
 
-			// Dry-run exits after the summary — before the prerequisite gate
-			// (which may install tools) and before any terraform runs, so this
-			// is hermetic.
 			if err := runCreateCluster(cmd, []string{"cloud-cluster"}); err != nil {
 				t.Fatalf("%s dry-run should return nil, got %v", clusterType, err)
 			}
+			if previewed == nil {
+				t.Fatal("cloud dry-run must invoke the terraform plan preview")
+			}
+			if previewed.Cloud == nil || previewed.Cloud.Region != "us-east-1" {
+				t.Fatalf("preview received wrong config: %+v", previewed)
+			}
 		})
+	}
+}
+
+func TestRunCreateCluster_K3dDryRunSkipsPlanPreview(t *testing.T) {
+	setupCreate(t)
+	called := false
+	orig := planPreviewFn
+	planPreviewFn = func(ctx context.Context, config models.ClusterConfig) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { planPreviewFn = orig })
+
+	cmd := getCreateCmd()
+	gf := utils.GetGlobalFlags()
+	gf.Create.SkipWizard = true
+	gf.Create.DryRun = true
+
+	if err := runCreateCluster(cmd, []string{"local-cluster"}); err != nil {
+		t.Fatalf("k3d dry-run should return nil, got %v", err)
+	}
+	if called {
+		t.Fatal("k3d dry-run must not invoke the terraform plan preview")
 	}
 }
 

--- a/cmd/cluster/delete.go
+++ b/cmd/cluster/delete.go
@@ -7,6 +7,8 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
+	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +52,24 @@ Examples:
 	return deleteCmd
 }
 
+// confirmCloudDeletion is the stronger destroy gate for cloud clusters:
+// re-typing the cluster name. Local clusters and --force pass through
+// (--force is the CI escape hatch); a non-interactive session without --force
+// refuses rather than hanging on a prompt — defense in depth behind the
+// generic confirmation, which may not always run before this.
+func confirmCloudDeletion(clusterType models.ClusterType, clusterName string, force bool) (bool, error) {
+	if clusterType != models.ClusterTypeEKS && clusterType != models.ClusterTypeGKE {
+		return true, nil
+	}
+	if force {
+		return true, nil
+	}
+	if sharedUI.IsNonInteractive() {
+		return false, fmt.Errorf("refusing to destroy cloud cluster '%s' non-interactively; pass --force to confirm", clusterName)
+	}
+	return ui.ConfirmTypedClusterName(clusterName)
+}
+
 func runDeleteCluster(cmd *cobra.Command, args []string) error {
 	service := utils.GetCommandService()
 	operationsUI := ui.NewOperationsUI()
@@ -80,6 +100,17 @@ func runDeleteCluster(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		operationsUI.ShowOperationError("delete", clusterName, err)
 		return fmt.Errorf("failed to detect cluster type: %w", err)
+	}
+
+	// Destroying a cloud cluster deletes billed infrastructure irreversibly,
+	// so it takes a stronger gate than the generic yes/no above.
+	proceed, err := confirmCloudDeletion(clusterType, clusterName, globalFlags.Delete.Force)
+	if err != nil {
+		return sharedErrors.HandleGlobalError(err, globalFlags.Global.Verbose)
+	}
+	if !proceed {
+		pterm.Info.Println("Cluster name did not match — nothing was deleted")
+		return nil
 	}
 
 	// Execute cluster deletion through service layer

--- a/cmd/cluster/delete_test.go
+++ b/cmd/cluster/delete_test.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
 )
@@ -20,4 +22,39 @@ func TestDeleteCommand(t *testing.T) {
 	}
 
 	testutil.TestClusterCommand(t, "delete", getDeleteCmd, setupFunc, teardownFunc)
+}
+
+// TestConfirmCloudDeletion locks the stronger destroy gate: cloud clusters
+// delete billed infrastructure, so a non-interactive delete without --force
+// must refuse instead of proceeding; --force and local clusters pass through.
+func TestConfirmCloudDeletion(t *testing.T) {
+	t.Setenv("CI", "true") // force ui.IsNonInteractive()
+
+	t.Run("k3d passes without confirmation", func(t *testing.T) {
+		proceed, err := confirmCloudDeletion(models.ClusterTypeK3d, "local", false)
+		if err != nil || !proceed {
+			t.Fatalf("k3d must pass through, got proceed=%v err=%v", proceed, err)
+		}
+	})
+
+	t.Run("cloud with force passes", func(t *testing.T) {
+		for _, clusterType := range []models.ClusterType{models.ClusterTypeEKS, models.ClusterTypeGKE} {
+			proceed, err := confirmCloudDeletion(clusterType, "cloudy", true)
+			if err != nil || !proceed {
+				t.Fatalf("%s with --force must pass, got proceed=%v err=%v", clusterType, proceed, err)
+			}
+		}
+	})
+
+	t.Run("cloud non-interactive without force refuses", func(t *testing.T) {
+		for _, clusterType := range []models.ClusterType{models.ClusterTypeEKS, models.ClusterTypeGKE} {
+			proceed, err := confirmCloudDeletion(clusterType, "cloudy", false)
+			if proceed || err == nil {
+				t.Fatalf("%s must refuse, got proceed=%v err=%v", clusterType, proceed, err)
+			}
+			if !strings.Contains(err.Error(), "refusing to destroy cloud cluster") {
+				t.Fatalf("expected the refusal message, got: %v", err)
+			}
+		}
+	})
 }

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -83,13 +83,23 @@ for the OSS tenant deployment.
 
 ## D5 — Cluster providers behind a unified interface
 
-Cluster creation goes through a `Provider` interface parameterized by
-**provider** (k3d local now; GKE/EKS later) and **target** (local vs cloud).
-Only **k3d** is implemented; cloud providers return a clear "coming soon"
-message. No new providers are added now — the interface exists so they can be
-added later without touching the rest of the CLI.
+Cluster creation goes through a `Provider` interface with three backends:
+**k3d** (local), **EKS**, and **GKE** (cloud). Backends are selected via the
+`provider.New(type)` factory, keyed on `ClusterConfig.Type`; the rest of the
+CLI never knows which backend runs. Cloud providers additionally implement
+`Planner` (`--dry-run` renders a real `terraform plan` footprint).
 
-For OSS the target is always **local** (k3d). SaaS targets (cloud) are future work.
+The cloud backends share one terraform engine (D7/D8): each generates a
+pinned, self-contained root module on the public `terraform-aws-modules` /
+`terraform-google-modules` modules and drives `terraform` via terraform-exec.
+Kubeconfig entries carry no static credentials — auth runs through the
+provider CLI exec plugins (`aws eks get-token`, `gke-gcloud-auth-plugin`),
+with the context named after the cluster so exact-match context resolution
+works unchanged.
+
+For OSS the default remains **local** (k3d); cloud clusters are an explicit
+`--type eks|gke` opt-in with a cost warning and a typed-name confirmation on
+delete.
 
 ---
 
@@ -109,6 +119,33 @@ typed argo-cd clientset. Benefits:
 - unblocks keeping `k8s.io/*` on the latest stable release.
 
 ---
+
+## D7 — Terraform (BUSL) as the provisioning engine, installed verified
+
+Cloud clusters are provisioned with **HashiCorp Terraform**, not OpenTofu.
+BUSL 1.1 only restricts "hosted or embedded" offerings **competitive with
+HashiCorp's products**; this CLI uses terraform as an internal tool to
+provision the user's own infrastructure, which is not a competitive offering.
+The binary is installed like every other prerequisite: a pinned version with
+SHA256 verification into `~/.openframe/bin` (no curl-pipe-bash, no sudo). An
+already-installed `terraform` on PATH in `~/.openframe/bin` is preferred.
+
+If a server-side scenario ever provisions clusters *as a service* with
+terraform, that is a different BUSL use profile and needs its own review.
+
+## D8 — Local terraform state in per-cluster workspaces
+
+Each cloud cluster owns a workspace under `~/.openframe/clusters/<name>/`:
+the generated root module, `terraform.tfvars.json`, local state, and a
+`cluster.json` registry record (type, status, endpoint/CA). The registry is
+what makes cloud clusters visible to `list`/`status`/`delete` without cloud
+API calls, and the state file is the only pointer to billed resources — so a
+workspace is **never deleted on a failed apply**, only after a successful
+destroy. Re-running `create` resumes an interrupted apply.
+
+Remote state is opt-in via `--backend-config s3://bucket/prefix` (EKS) or
+`gcs://bucket/prefix` (GKE) for users who need the state to survive the
+machine that created the cluster.
 
 ## Platform support
 

--- a/internal/cluster/models/cluster.go
+++ b/internal/cluster/models/cluster.go
@@ -32,6 +32,10 @@ type CloudConfig struct {
 	MinNodes    int    `json:"min_nodes,omitempty"`
 	MaxNodes    int    `json:"max_nodes,omitempty"`
 	Spot        bool   `json:"spot,omitempty"`
+	// BackendConfig is an optional remote-state location
+	// (s3://bucket/prefix for EKS, gcs://bucket/prefix for GKE);
+	// empty means local state in the cluster workspace.
+	BackendConfig string `json:"backend_config,omitempty"`
 }
 
 // ClusterInfo represents information about a cluster

--- a/internal/cluster/models/flags.go
+++ b/internal/cluster/models/flags.go
@@ -21,13 +21,14 @@ type CreateFlags struct {
 	SkipWizard  bool
 
 	// Cloud-only flags (EKS/GKE)
-	Region      string
-	Profile     string // AWS
-	Project     string // GCP
-	MachineType string
-	MinNodes    int
-	MaxNodes    int
-	Spot        bool
+	Region        string
+	Profile       string // AWS
+	Project       string // GCP
+	MachineType   string
+	MinNodes      int
+	MaxNodes      int
+	Spot          bool
+	BackendConfig string
 }
 
 // ListFlags contains flags specific to list command
@@ -77,6 +78,7 @@ func AddCreateFlags(cmd *cobra.Command, flags *CreateFlags) {
 	cmd.Flags().IntVar(&flags.MinNodes, "min-nodes", 0, "Node group minimum size (cloud only)")
 	cmd.Flags().IntVar(&flags.MaxNodes, "max-nodes", 0, "Node group maximum size (cloud only)")
 	cmd.Flags().BoolVar(&flags.Spot, "spot", false, "Use spot capacity for nodes (cloud only)")
+	cmd.Flags().StringVar(&flags.BackendConfig, "backend-config", "", "Remote terraform state: s3://bucket/prefix (eks) or gcs://bucket/prefix (gke); default is local state")
 }
 
 // AddListFlags adds list-specific flags to a command
@@ -165,6 +167,9 @@ func ValidateCreateFlags(flags *CreateFlags) error {
 	}
 	if clusterType == ClusterTypeGKE && flags.SkipWizard && flags.Project == "" {
 		return fmt.Errorf("--project is required for --type gke with --skip-wizard")
+	}
+	if flags.BackendConfig != "" && !isCloud {
+		return fmt.Errorf("--backend-config only applies to cloud cluster types (eks, gke)")
 	}
 	if flags.MinNodes < 0 || flags.MaxNodes < 0 {
 		return fmt.Errorf("node bounds must not be negative: min=%d max=%d", flags.MinNodes, flags.MaxNodes)

--- a/internal/cluster/models/flags_test.go
+++ b/internal/cluster/models/flags_test.go
@@ -332,3 +332,17 @@ func TestFlagValidation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestValidateCreateFlags_BackendConfig(t *testing.T) {
+	t.Run("accepted for cloud types", func(t *testing.T) {
+		flags := &CreateFlags{ClusterType: "eks", SkipWizard: true, Region: "us-east-1", NodeCount: 3, BackendConfig: "s3://bucket/prefix"}
+		assert.NoError(t, ValidateCreateFlags(flags))
+	})
+
+	t.Run("rejected for k3d", func(t *testing.T) {
+		flags := &CreateFlags{ClusterType: "k3d", NodeCount: 3, BackendConfig: "s3://bucket/prefix"}
+		err := ValidateCreateFlags(flags)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only applies to cloud cluster types")
+	})
+}

--- a/internal/cluster/provider/provider.go
+++ b/internal/cluster/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/eks"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/gke"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/k3d"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"k8s.io/client-go/rest"
 )
 
@@ -41,6 +42,14 @@ type Provider interface {
 	GetKubeconfig(ctx context.Context, name string, clusterType models.ClusterType) (string, error)
 }
 
+// Planner is the optional preview capability of cloud providers: a real
+// terraform plan of what CreateCluster would do, without registering the
+// cluster or touching state. k3d has no meaningful plan, so this is a
+// separate interface rather than a tenth Provider method.
+type Planner interface {
+	PlanCluster(ctx context.Context, config models.ClusterConfig) (terraform.PlanSummary, error)
+}
+
 // Compile-time assertions that the backends satisfy Provider.
 //
 // Backends are selected through New (factory.go). The old decorative factory
@@ -50,4 +59,6 @@ var (
 	_ Provider = (*k3d.K3dManager)(nil)
 	_ Provider = (*eks.Provider)(nil)
 	_ Provider = (*gke.Provider)(nil)
+	_ Planner  = (*eks.Provider)(nil)
+	_ Planner  = (*gke.Provider)(nil)
 )

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -8,6 +8,7 @@ package eks
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -61,11 +62,76 @@ func (p *Provider) preflightCredentials(ctx context.Context, profile string) err
 	return nil
 }
 
+// backendTF renders the s3 backend block for an EKS workspace.
+func backendTF(cfg tfengine.BackendConfig, region string) []byte {
+	key := "terraform.tfstate"
+	if cfg.Prefix != "" {
+		key = cfg.Prefix + "/terraform.tfstate"
+	}
+	return []byte(fmt.Sprintf(
+		"terraform {\n  backend \"s3\" {\n    bucket = %q\n    key    = %q\n    region = %q\n  }\n}\n",
+		cfg.Bucket, key, region))
+}
+
+// parseBackend validates the optional --backend-config value for EKS.
+func parseBackend(config models.ClusterConfig) (*tfengine.BackendConfig, error) {
+	if config.Cloud.BackendConfig == "" {
+		return nil, nil
+	}
+	cfg, err := tfengine.ParseBackendURL(config.Cloud.BackendConfig)
+	if err != nil {
+		return nil, models.NewInvalidConfigError("backend-config", config.Cloud.BackendConfig, err.Error())
+	}
+	if cfg.Scheme != "s3" {
+		return nil, models.NewInvalidConfigError("backend-config", config.Cloud.BackendConfig, "EKS remote state must be s3://bucket/prefix")
+	}
+	return &cfg, nil
+}
+
+// PlanCluster previews what CreateCluster would do — a real terraform plan —
+// without registering the cluster or touching any state. A brand-new cluster
+// is planned in a throwaway directory; an existing (failed/interrupted)
+// workspace is planned in place to show what a resume would change.
+func (p *Provider) PlanCluster(ctx context.Context, config models.ClusterConfig) (tfengine.PlanSummary, error) {
+	if err := validate(config); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+	if err := p.preflightCredentials(ctx, config.Cloud.Profile); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+
+	dir := p.registry.Workspace(config.Name).TerraformDir()
+	if !p.registry.Workspace(config.Name).Exists() {
+		vars, err := tfvarsFor(config)
+		if err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		tmp, err := os.MkdirTemp("", "openframe-plan-*")
+		if err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+		if err := tfengine.WriteModule(tmp, mainTF, vars); err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		dir = tmp
+	}
+
+	if err := p.engine.Init(ctx, dir); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+	return p.engine.Plan(ctx, dir)
+}
+
 // CreateCluster provisions the cluster and returns a rest.Config for it.
 // Re-running after a failed apply resumes the same workspace: terraform apply
 // is idempotent over the recorded state.
 func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfig) (*rest.Config, error) {
 	if err := validate(config); err != nil {
+		return nil, err
+	}
+	backend, err := parseBackend(config)
+	if err != nil {
 		return nil, err
 	}
 	if err := p.preflightCredentials(ctx, config.Cloud.Profile); err != nil {
@@ -90,6 +156,11 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 		}
 		if err := ws.Scaffold(record, mainTF, vars); err != nil {
 			return nil, err
+		}
+		if backend != nil {
+			if err := ws.WriteBackend(backendTF(*backend, config.Cloud.Region)); err != nil {
+				return nil, err
+			}
 		}
 	}
 	// An existing workspace means a previous create failed or was interrupted;

--- a/internal/cluster/providers/eks/provider_test.go
+++ b/internal/cluster/providers/eks/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,14 +37,29 @@ func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) erro
 	return f.applyErr
 }
 
+func (f *fakeRunner) ApplyJSON(ctx context.Context, w io.Writer, opts ...tfexec.ApplyOption) error {
+	return f.Apply(ctx)
+}
+
 func (f *fakeRunner) Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error {
 	*f.calls = append(*f.calls, "destroy")
 	return nil
 }
 
+func (f *fakeRunner) DestroyJSON(ctx context.Context, w io.Writer, opts ...tfexec.DestroyOption) error {
+	return f.Destroy(ctx)
+}
+
 func (f *fakeRunner) Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error) {
 	*f.calls = append(*f.calls, "plan")
 	return true, nil
+}
+
+func (f *fakeRunner) ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error) {
+	*f.calls = append(*f.calls, "show")
+	return &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+		{Change: &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionCreate}}},
+	}}, nil
 }
 
 func (f *fakeRunner) Output(ctx context.Context, opts ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error) {
@@ -232,4 +249,45 @@ func TestTemplateEmbedsModulePins(t *testing.T) {
 	assert.Contains(t, tf, `source  = "terraform-aws-modules/vpc/aws"`)
 	assert.Contains(t, tf, `version = "~> 6.0"`)
 	assert.Contains(t, tf, "enable_cluster_creator_admin_permissions = true")
+}
+
+func TestPlanCluster_NewClusterDoesNotRegister(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+
+	summary, err := p.PlanCluster(context.Background(), eksConfig("demo"))
+	require.NoError(t, err)
+	assert.True(t, summary.HasChanges())
+	assert.Equal(t, []string{"init", "plan", "show"}, *calls)
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound, "a plan preview must not register the cluster")
+}
+
+func TestCreateCluster_WritesS3Backend(t *testing.T) {
+	p, _, registry := newTestProvider(t, nil)
+	config := eksConfig("demo")
+	config.Cloud.BackendConfig = "s3://my-bucket/clusters/demo"
+
+	_, err := p.CreateCluster(context.Background(), config)
+	require.NoError(t, err)
+
+	backend, err := os.ReadFile(filepath.Join(registry.Workspace("demo").TerraformDir(), "backend.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(backend), `backend "s3"`)
+	assert.Contains(t, string(backend), `bucket = "my-bucket"`)
+	assert.Contains(t, string(backend), `key    = "clusters/demo/terraform.tfstate"`)
+	assert.Contains(t, string(backend), `region = "us-east-1"`)
+}
+
+func TestCreateCluster_RejectsGCSBackend(t *testing.T) {
+	p, calls, _ := newTestProvider(t, nil)
+	config := eksConfig("demo")
+	config.Cloud.BackendConfig = "gcs://my-bucket/prefix"
+
+	_, err := p.CreateCluster(context.Background(), config)
+	var invalid models.ErrInvalidClusterConfig
+	require.ErrorAs(t, err, &invalid)
+	assert.Contains(t, err.Error(), "must be s3://")
+	assert.Empty(t, *calls)
 }

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -9,6 +9,7 @@ package gke
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -57,10 +58,71 @@ func (p *Provider) preflightCredentials(ctx context.Context, project string) err
 	return nil
 }
 
+// backendTF renders the gcs backend block for a GKE workspace.
+func backendTF(cfg tfengine.BackendConfig) []byte {
+	return []byte(fmt.Sprintf(
+		"terraform {\n  backend \"gcs\" {\n    bucket = %q\n    prefix = %q\n  }\n}\n",
+		cfg.Bucket, cfg.Prefix))
+}
+
+// parseBackend validates the optional --backend-config value for GKE.
+func parseBackend(config models.ClusterConfig) (*tfengine.BackendConfig, error) {
+	if config.Cloud.BackendConfig == "" {
+		return nil, nil
+	}
+	cfg, err := tfengine.ParseBackendURL(config.Cloud.BackendConfig)
+	if err != nil {
+		return nil, models.NewInvalidConfigError("backend-config", config.Cloud.BackendConfig, err.Error())
+	}
+	if cfg.Scheme != "gcs" {
+		return nil, models.NewInvalidConfigError("backend-config", config.Cloud.BackendConfig, "GKE remote state must be gcs://bucket/prefix")
+	}
+	return &cfg, nil
+}
+
+// PlanCluster previews what CreateCluster would do — a real terraform plan —
+// without registering the cluster or touching any state. A brand-new cluster
+// is planned in a throwaway directory; an existing (failed/interrupted)
+// workspace is planned in place to show what a resume would change.
+func (p *Provider) PlanCluster(ctx context.Context, config models.ClusterConfig) (tfengine.PlanSummary, error) {
+	if err := validate(config); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+	if err := p.preflightCredentials(ctx, config.Cloud.Project); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+
+	dir := p.registry.Workspace(config.Name).TerraformDir()
+	if !p.registry.Workspace(config.Name).Exists() {
+		vars, err := tfvarsFor(config)
+		if err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		tmp, err := os.MkdirTemp("", "openframe-plan-*")
+		if err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+		if err := tfengine.WriteModule(tmp, mainTF, vars); err != nil {
+			return tfengine.PlanSummary{}, err
+		}
+		dir = tmp
+	}
+
+	if err := p.engine.Init(ctx, dir); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+	return p.engine.Plan(ctx, dir)
+}
+
 // CreateCluster provisions the cluster and returns a rest.Config for it.
 // Re-running after a failed apply resumes the same workspace.
 func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfig) (*rest.Config, error) {
 	if err := validate(config); err != nil {
+		return nil, err
+	}
+	backend, err := parseBackend(config)
+	if err != nil {
 		return nil, err
 	}
 	if err := p.preflightCredentials(ctx, config.Cloud.Project); err != nil {
@@ -85,6 +147,11 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 		}
 		if err := ws.Scaffold(record, mainTF, vars); err != nil {
 			return nil, err
+		}
+		if backend != nil {
+			if err := ws.WriteBackend(backendTF(*backend)); err != nil {
+				return nil, err
+			}
 		}
 	}
 	// An existing workspace means a previous create failed or was interrupted;

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,14 +37,29 @@ func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) erro
 	return f.applyErr
 }
 
+func (f *fakeRunner) ApplyJSON(ctx context.Context, w io.Writer, opts ...tfexec.ApplyOption) error {
+	return f.Apply(ctx)
+}
+
 func (f *fakeRunner) Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error {
 	*f.calls = append(*f.calls, "destroy")
 	return nil
 }
 
+func (f *fakeRunner) DestroyJSON(ctx context.Context, w io.Writer, opts ...tfexec.DestroyOption) error {
+	return f.Destroy(ctx)
+}
+
 func (f *fakeRunner) Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error) {
 	*f.calls = append(*f.calls, "plan")
 	return true, nil
+}
+
+func (f *fakeRunner) ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error) {
+	*f.calls = append(*f.calls, "show")
+	return &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+		{Change: &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionCreate}}},
+	}}, nil
 }
 
 func (f *fakeRunner) Output(ctx context.Context, opts ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error) {
@@ -229,4 +246,44 @@ func TestTemplateEmbedsModulePins(t *testing.T) {
 	assert.Contains(t, tf, `source  = "terraform-google-modules/network/google"`)
 	assert.Contains(t, tf, `version = "~> 18.0"`)
 	assert.Contains(t, tf, "deletion_protection = false")
+}
+
+func TestPlanCluster_NewClusterDoesNotRegister(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+
+	summary, err := p.PlanCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err)
+	assert.True(t, summary.HasChanges())
+	assert.Equal(t, []string{"init", "plan", "show"}, *calls)
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound, "a plan preview must not register the cluster")
+}
+
+func TestCreateCluster_WritesGCSBackend(t *testing.T) {
+	p, _, registry := newTestProvider(t, nil)
+	config := gkeConfig("demo")
+	config.Cloud.BackendConfig = "gcs://my-bucket/clusters/demo"
+
+	_, err := p.CreateCluster(context.Background(), config)
+	require.NoError(t, err)
+
+	backend, err := os.ReadFile(filepath.Join(registry.Workspace("demo").TerraformDir(), "backend.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(backend), `backend "gcs"`)
+	assert.Contains(t, string(backend), `bucket = "my-bucket"`)
+	assert.Contains(t, string(backend), `prefix = "clusters/demo"`)
+}
+
+func TestCreateCluster_RejectsS3Backend(t *testing.T) {
+	p, calls, _ := newTestProvider(t, nil)
+	config := gkeConfig("demo")
+	config.Cloud.BackendConfig = "s3://my-bucket/prefix"
+
+	_, err := p.CreateCluster(context.Background(), config)
+	var invalid models.ErrInvalidClusterConfig
+	require.ErrorAs(t, err, &invalid)
+	assert.Contains(t, err.Error(), "must be gcs://")
+	assert.Empty(t, *calls)
 }

--- a/internal/cluster/providers/terraform/backend.go
+++ b/internal/cluster/providers/terraform/backend.go
@@ -1,0 +1,47 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Remote state is opt-in: --backend-config s3://bucket/prefix (EKS) or
+// gcs://bucket/prefix (GKE). The default stays local state in the workspace —
+// remote state protects against losing the machine that created the cluster.
+
+// BackendConfig is a parsed --backend-config value.
+type BackendConfig struct {
+	Scheme string // "s3" or "gcs"
+	Bucket string
+	Prefix string
+}
+
+// backendPartRE constrains bucket/prefix to characters that are safe to
+// interpolate into generated HCL (defense in depth — values also come from a
+// validated flag).
+var backendPartRE = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// ParseBackendURL parses scheme://bucket[/prefix].
+func ParseBackendURL(raw string) (BackendConfig, error) {
+	scheme, rest, found := strings.Cut(raw, "://")
+	if !found || (scheme != "s3" && scheme != "gcs") {
+		return BackendConfig{}, fmt.Errorf("invalid backend %q: expected s3://bucket/prefix or gcs://bucket/prefix", raw)
+	}
+	bucket, prefix, _ := strings.Cut(rest, "/")
+	if bucket == "" || !backendPartRE.MatchString(bucket) || (prefix != "" && !backendPartRE.MatchString(prefix)) {
+		return BackendConfig{}, fmt.Errorf("invalid backend %q: bucket/prefix may contain only letters, digits, '.', '_', '-' and '/'", raw)
+	}
+	return BackendConfig{Scheme: scheme, Bucket: bucket, Prefix: prefix}, nil
+}
+
+// WriteBackend writes backend.tf next to the generated main.tf. Callers pass
+// the rendered HCL for their provider's backend type.
+func (w *Workspace) WriteBackend(backendTF []byte) error {
+	if err := os.MkdirAll(w.TerraformDir(), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(w.TerraformDir(), "backend.tf"), backendTF, 0o600)
+}

--- a/internal/cluster/providers/terraform/backend_test.go
+++ b/internal/cluster/providers/terraform/backend_test.go
@@ -1,0 +1,44 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBackendURL(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    BackendConfig
+		wantErr bool
+	}{
+		{"s3://bucket/some/prefix", BackendConfig{Scheme: "s3", Bucket: "bucket", Prefix: "some/prefix"}, false},
+		{"gcs://bucket", BackendConfig{Scheme: "gcs", Bucket: "bucket"}, false},
+		{"gcs://bucket/prefix", BackendConfig{Scheme: "gcs", Bucket: "bucket", Prefix: "prefix"}, false},
+		{"http://bucket/prefix", BackendConfig{}, true},
+		{"s3://", BackendConfig{}, true},
+		{"just-a-bucket", BackendConfig{}, true},
+		{`s3://bu"cket/prefix`, BackendConfig{}, true}, // HCL-hostile characters rejected
+	}
+	for _, tc := range cases {
+		got, err := ParseBackendURL(tc.in)
+		if tc.wantErr {
+			assert.Error(t, err, "input %q", tc.in)
+			continue
+		}
+		require.NoError(t, err, "input %q", tc.in)
+		assert.Equal(t, tc.want, got, "input %q", tc.in)
+	}
+}
+
+func TestWorkspace_WriteBackend(t *testing.T) {
+	ws := OpenWorkspace(t.TempDir(), "demo")
+	require.NoError(t, ws.WriteBackend([]byte("terraform {}\n")))
+
+	data, err := os.ReadFile(filepath.Join(ws.TerraformDir(), "backend.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, "terraform {}\n", string(data))
+}

--- a/internal/cluster/providers/terraform/engine.go
+++ b/internal/cluster/providers/terraform/engine.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/flamingo-stack/openframe-cli/internal/shared/download"
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 // Runner is the subset of *tfexec.Terraform the engine uses; an interface so
@@ -16,8 +19,11 @@ import (
 type Runner interface {
 	Init(ctx context.Context, opts ...tfexec.InitOption) error
 	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
+	ApplyJSON(ctx context.Context, w io.Writer, opts ...tfexec.ApplyOption) error
 	Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error
+	DestroyJSON(ctx context.Context, w io.Writer, opts ...tfexec.DestroyOption) error
 	Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error)
+	ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error)
 	Output(ctx context.Context, opts ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error)
 }
 
@@ -84,42 +90,79 @@ func (e *Engine) Init(ctx context.Context, dir string) error {
 	return nil
 }
 
-// Apply runs terraform apply in dir. It is idempotent: re-running after a
-// partial failure resumes from the recorded state.
+// Apply runs terraform apply in dir, streaming per-resource progress lines
+// (via terraform's machine-readable -json output) so a 15-minute cloud apply
+// is never a silent wait. It is idempotent: re-running after a partial
+// failure resumes from the recorded state.
 func (e *Engine) Apply(ctx context.Context, dir string) error {
 	tf, err := e.newRunner(dir)
 	if err != nil {
 		return err
 	}
-	if err := tf.Apply(ctx); err != nil {
+	if err := tf.ApplyJSON(ctx, newProgressWriter(e.verbose)); err != nil {
 		return fmt.Errorf("terraform apply failed: %w", err)
 	}
 	return nil
 }
 
-// Destroy runs terraform destroy in dir.
+// Destroy runs terraform destroy in dir, streaming progress like Apply.
 func (e *Engine) Destroy(ctx context.Context, dir string) error {
 	tf, err := e.newRunner(dir)
 	if err != nil {
 		return err
 	}
-	if err := tf.Destroy(ctx); err != nil {
+	if err := tf.DestroyJSON(ctx, newProgressWriter(e.verbose)); err != nil {
 		return fmt.Errorf("terraform destroy failed: %w", err)
 	}
 	return nil
 }
 
-// Plan runs terraform plan in dir and reports whether changes are pending.
-func (e *Engine) Plan(ctx context.Context, dir string) (bool, error) {
+// PlanSummary is the resource-change footprint of a terraform plan.
+type PlanSummary struct {
+	Add     int
+	Change  int
+	Destroy int
+}
+
+// HasChanges reports whether the plan would modify anything.
+func (s PlanSummary) HasChanges() bool { return s.Add+s.Change+s.Destroy > 0 }
+
+// Plan runs terraform plan in dir and summarizes the pending changes by
+// resource action (create/update/delete).
+func (e *Engine) Plan(ctx context.Context, dir string) (PlanSummary, error) {
 	tf, err := e.newRunner(dir)
 	if err != nil {
-		return false, err
+		return PlanSummary{}, err
 	}
-	changes, err := tf.Plan(ctx)
+	planFile := filepath.Join(dir, "tfplan")
+	defer func() { _ = os.Remove(planFile) }()
+
+	changes, err := tf.Plan(ctx, tfexec.Out(planFile))
 	if err != nil {
-		return false, fmt.Errorf("terraform plan failed: %w", err)
+		return PlanSummary{}, fmt.Errorf("terraform plan failed: %w", err)
 	}
-	return changes, nil
+	if !changes {
+		return PlanSummary{}, nil
+	}
+	plan, err := tf.ShowPlanFile(ctx, planFile)
+	if err != nil {
+		return PlanSummary{}, fmt.Errorf("terraform show failed: %w", err)
+	}
+	var summary PlanSummary
+	for _, rc := range plan.ResourceChanges {
+		switch {
+		case rc.Change.Actions.Create():
+			summary.Add++
+		case rc.Change.Actions.Update():
+			summary.Change++
+		case rc.Change.Actions.Delete():
+			summary.Destroy++
+		case rc.Change.Actions.Replace():
+			summary.Add++
+			summary.Destroy++
+		}
+	}
+	return summary, nil
 }
 
 // Outputs returns the root-module outputs of dir as raw JSON values.

--- a/internal/cluster/providers/terraform/engine_test.go
+++ b/internal/cluster/providers/terraform/engine_test.go
@@ -4,19 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // fakeRunner records calls and returns canned results.
 type fakeRunner struct {
-	calls   []string
-	initErr error
-	apply   error
-	outputs map[string]tfexec.OutputMeta
+	calls       []string
+	initErr     error
+	apply       error
+	outputs     map[string]tfexec.OutputMeta
+	planChanges bool
+	plan        *tfjson.Plan
+	applyJSON   string // lines streamed into the writer by ApplyJSON
 }
 
 func (f *fakeRunner) Init(ctx context.Context, opts ...tfexec.InitOption) error {
@@ -29,14 +34,32 @@ func (f *fakeRunner) Apply(ctx context.Context, opts ...tfexec.ApplyOption) erro
 	return f.apply
 }
 
+func (f *fakeRunner) ApplyJSON(ctx context.Context, w io.Writer, opts ...tfexec.ApplyOption) error {
+	f.calls = append(f.calls, "apply")
+	if f.applyJSON != "" {
+		_, _ = w.Write([]byte(f.applyJSON))
+	}
+	return f.apply
+}
+
 func (f *fakeRunner) Destroy(ctx context.Context, opts ...tfexec.DestroyOption) error {
+	f.calls = append(f.calls, "destroy")
+	return nil
+}
+
+func (f *fakeRunner) DestroyJSON(ctx context.Context, w io.Writer, opts ...tfexec.DestroyOption) error {
 	f.calls = append(f.calls, "destroy")
 	return nil
 }
 
 func (f *fakeRunner) Plan(ctx context.Context, opts ...tfexec.PlanOption) (bool, error) {
 	f.calls = append(f.calls, "plan")
-	return true, nil
+	return f.planChanges, nil
+}
+
+func (f *fakeRunner) ShowPlanFile(ctx context.Context, planPath string, opts ...tfexec.ShowOption) (*tfjson.Plan, error) {
+	f.calls = append(f.calls, "show")
+	return f.plan, nil
 }
 
 func (f *fakeRunner) Output(ctx context.Context, opts ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error) {
@@ -57,9 +80,9 @@ func TestEngine_LifecycleCalls(t *testing.T) {
 
 	require.NoError(t, e.Init(ctx, "dir"))
 	require.NoError(t, e.Apply(ctx, "dir"))
-	changes, err := e.Plan(ctx, "dir")
+	changes, err := e.Plan(ctx, t.TempDir())
 	require.NoError(t, err)
-	assert.True(t, changes)
+	assert.False(t, changes.HasChanges(), "planChanges=false must summarize to no changes")
 	require.NoError(t, e.Destroy(ctx, "dir"))
 
 	outputs, err := e.Outputs(ctx, "dir")
@@ -69,6 +92,72 @@ func TestEngine_LifecycleCalls(t *testing.T) {
 	assert.Equal(t, "https://example.eks", endpoint)
 
 	assert.Equal(t, []string{"init", "apply", "plan", "destroy", "output"}, f.calls)
+}
+
+// action builds a tfjson resource change with the given actions.
+func action(actions ...tfjson.Action) *tfjson.ResourceChange {
+	return &tfjson.ResourceChange{Change: &tfjson.Change{Actions: actions}}
+}
+
+func TestEngine_PlanSummaryCountsActions(t *testing.T) {
+	f := &fakeRunner{
+		planChanges: true,
+		plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+			action(tfjson.ActionCreate),
+			action(tfjson.ActionCreate),
+			action(tfjson.ActionUpdate),
+			action(tfjson.ActionDelete),
+			action(tfjson.ActionDelete, tfjson.ActionCreate), // replace
+		}},
+	}
+	summary, err := engineWith(f).Plan(context.Background(), t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, PlanSummary{Add: 3, Change: 1, Destroy: 2}, summary)
+	assert.True(t, summary.HasChanges())
+	assert.Contains(t, f.calls, "show")
+}
+
+func TestProgressLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		verbose bool
+		want    string
+		ok      bool
+	}{
+		{"apply start shown", `{"@message":"aws_eks_cluster.this: Creating...","type":"apply_start"}`, false, "aws_eks_cluster.this: Creating...", true},
+		{"apply complete shown", `{"@message":"aws_eks_cluster.this: Creation complete after 9m2s","type":"apply_complete"}`, false, "aws_eks_cluster.this: Creation complete after 9m2s", true},
+		{"change summary shown", `{"@message":"Apply complete! Resources: 47 added.","type":"change_summary"}`, false, "Apply complete! Resources: 47 added.", true},
+		{"progress ticks dropped", `{"@message":"still creating...","type":"apply_progress"}`, false, "", false},
+		{"refresh noise dropped", `{"@message":"Refreshing state...","type":"refresh_start"}`, false, "", false},
+		{"error diagnostics shown", `{"@level":"error","@message":"Error: quota exceeded","type":"diagnostic"}`, false, "Error: quota exceeded", true},
+		{"warning diagnostics dropped", `{"@level":"warn","@message":"deprecation","type":"diagnostic"}`, false, "", false},
+		{"verbose forwards everything", `{"@message":"still creating...","type":"apply_progress"}`, true, "still creating...", true},
+		{"garbage dropped", `not json`, false, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := progressLine([]byte(tc.line), tc.verbose)
+			assert.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestProgressWriter_HandlesPartialLines(t *testing.T) {
+	w := newProgressWriter(false).(*progressWriter)
+	line := `{"@message":"done","type":"apply_complete"}` + "\n"
+	half := len(line) / 2
+
+	n, err := w.Write([]byte(line[:half]))
+	require.NoError(t, err)
+	assert.Equal(t, half, n)
+	n, err = w.Write([]byte(line[half:]))
+	require.NoError(t, err)
+	assert.Equal(t, len(line)-half, n)
+	assert.Zero(t, w.buf.Len(), "a completed line must be fully consumed")
 }
 
 func TestEngine_WrapsErrors(t *testing.T) {

--- a/internal/cluster/providers/terraform/progress.go
+++ b/internal/cluster/providers/terraform/progress.go
@@ -1,0 +1,69 @@
+package terraform
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/pterm/pterm"
+)
+
+// Terraform's -json output is one JSON object per line (machine-readable UI
+// protocol). progressWriter turns the interesting ones into short pterm lines
+// so long applies show per-resource progress; pterm printers respect --silent.
+
+// applyEvent is the subset of the terraform JSON-UI schema the writer reads.
+type applyEvent struct {
+	Level   string `json:"@level"`
+	Message string `json:"@message"`
+	Type    string `json:"type"`
+}
+
+// progressLine converts one JSON event line into a display string; ok=false
+// means the event is noise (refresh/progress ticks) and prints nothing.
+// Verbose forwards every event message instead.
+func progressLine(line []byte, verbose bool) (string, bool) {
+	var ev applyEvent
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return "", false // not an event line (e.g. blank) — drop
+	}
+	if verbose {
+		return ev.Message, ev.Message != ""
+	}
+	switch ev.Type {
+	case "apply_start", "apply_complete", "apply_errored", "change_summary":
+		return ev.Message, ev.Message != ""
+	case "diagnostic":
+		// Errors surface through the returned error too, but printing them in
+		// stream order preserves the context of what was being created.
+		return ev.Message, ev.Level == "error" && ev.Message != ""
+	default:
+		return "", false
+	}
+}
+
+// progressWriter buffers partial writes into lines and prints each event.
+type progressWriter struct {
+	verbose bool
+	buf     bytes.Buffer
+}
+
+func newProgressWriter(verbose bool) io.Writer {
+	return &progressWriter{verbose: verbose}
+}
+
+func (w *progressWriter) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+	for {
+		line, err := w.buf.ReadBytes('\n')
+		if err != nil {
+			// No full line yet — keep the partial for the next Write.
+			w.buf.Write(line)
+			break
+		}
+		if msg, ok := progressLine(bytes.TrimSpace(line), w.verbose); ok {
+			pterm.DefaultBasicText.Printf("  %s\n", msg)
+		}
+	}
+	return len(p), nil
+}

--- a/internal/cluster/providers/terraform/workspace.go
+++ b/internal/cluster/providers/terraform/workspace.go
@@ -84,22 +84,29 @@ func (w *Workspace) Exists() bool {
 	return err == nil
 }
 
-// Scaffold creates the workspace directories and writes the generated root
-// module, tfvars, and the initial record. It refuses to overwrite an existing
-// terraform state (a partially-created cluster must be resumed or destroyed,
-// never silently re-scaffolded over).
-func (w *Workspace) Scaffold(record Record, mainTF []byte, tfvars any) error {
-	if err := os.MkdirAll(w.TerraformDir(), 0o750); err != nil {
-		return fmt.Errorf("creating workspace %s: %w", w.dir, err)
+// WriteModule writes a generated root module (main.tf + terraform.tfvars.json)
+// into dir. Used by Scaffold for real workspaces and by plan previews for
+// throwaway directories.
+func WriteModule(dir string, mainTF []byte, tfvars any) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("creating module dir %s: %w", dir, err)
 	}
 	varsJSON, err := json.MarshalIndent(tfvars, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encoding tfvars: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(w.TerraformDir(), "main.tf"), mainTF, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), mainTF, 0o600); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(w.TerraformDir(), "terraform.tfvars.json"), varsJSON, 0o600); err != nil {
+	return os.WriteFile(filepath.Join(dir, "terraform.tfvars.json"), varsJSON, 0o600)
+}
+
+// Scaffold creates the workspace directories and writes the generated root
+// module, tfvars, and the initial record. It refuses to overwrite an existing
+// terraform state (a partially-created cluster must be resumed or destroyed,
+// never silently re-scaffolded over).
+func (w *Workspace) Scaffold(record Record, mainTF []byte, tfvars any) error {
+	if err := WriteModule(w.TerraformDir(), mainTF, tfvars); err != nil {
 		return err
 	}
 	return w.WriteRecord(record)

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -153,13 +153,14 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 		return restConfig, nil // Exit gracefully without error
 	}
 
-	// Cluster doesn't exist, proceed with creation
+	// Cluster doesn't exist, proceed with creation. Cloud creates stream
+	// per-resource progress lines from the terraform engine, which a spinner's
+	// redraws would garble — so the spinner is k3d-only.
 	var sp *spinner.Spinner
-	if !s.suppressUI {
+	if !s.suppressUI && config.Type == models.ClusterTypeK3d {
 		sp = spinner.New()
 		sp.Start(fmt.Sprintf("Creating %s cluster '%s'...", config.Type, config.Name))
 	} else {
-		// In non-interactive mode, just show a simple info message
 		pterm.Info.Printf("Creating %s cluster '%s'...\n", config.Type, config.Name)
 	}
 
@@ -195,9 +196,10 @@ func (s *ClusterService) DeleteCluster(ctx context.Context, name string, cluster
 		return err
 	}
 
-	// Show deletion progress
+	// Show deletion progress. Cloud destroys stream terraform progress lines,
+	// so the spinner is k3d-only (same reasoning as CreateCluster).
 	var sp *spinner.Spinner
-	if !s.suppressUI {
+	if !s.suppressUI && clusterType == models.ClusterTypeK3d {
 		sp = spinner.New()
 		sp.Start(fmt.Sprintf("Deleting %s cluster '%s'...", clusterType, name))
 	} else {

--- a/internal/cluster/ui/operations.go
+++ b/internal/cluster/ui/operations.go
@@ -344,7 +344,7 @@ func (ui *OperationsUI) ShowConfigurationSummary(config models.ClusterConfig, dr
 		if config.Cloud.MachineType != "" {
 			pterm.DefaultBasicText.Printf("Instance: %s\n", config.Cloud.MachineType)
 		}
-		pterm.Warning.Println("Cloud clusters create resources that incur costs (managed control plane, VM nodes, NAT)")
+		pterm.Warning.Println(CostHint(config.Type))
 	}
 
 	pterm.DefaultBasicText.Println()

--- a/internal/cluster/ui/prompts.go
+++ b/internal/cluster/ui/prompts.go
@@ -1,8 +1,12 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/manifoldco/promptui"
 	"github.com/pterm/pterm"
 )
 
@@ -48,4 +52,32 @@ func SelectClusterByName(clusters []ClusterInfo, prompt string) (string, error) 
 func selectFromList(prompt string, items []string) (int, string, error) {
 	// Use common UI function
 	return sharedUI.SelectFromList(prompt, items)
+}
+
+// CostHint is the running-cost warning shown for cloud cluster types. The
+// figures are deliberately rough baselines, not quotes.
+func CostHint(clusterType models.ClusterType) string {
+	switch clusterType {
+	case models.ClusterTypeEKS:
+		return "This creates billed AWS resources: EKS control plane (~$73/mo), EC2 nodes, and a NAT gateway (~$33/mo + traffic)"
+	case models.ClusterTypeGKE:
+		return "This creates billed GCP resources: GKE cluster management fee (~$73/mo), VM nodes, and networking"
+	default:
+		return "Cloud clusters create resources that incur costs"
+	}
+}
+
+// ConfirmTypedClusterName requires the user to re-type the cluster name
+// before a cloud destroy — a stronger gate than yes/no, because the action
+// deletes billed infrastructure irreversibly.
+func ConfirmTypedClusterName(name string) (bool, error) {
+	pterm.Warning.Printf("Deleting a cloud cluster destroys all its cloud resources.\n")
+	prompt := promptui.Prompt{
+		Label: fmt.Sprintf("Type the cluster name (%s) to confirm", name),
+	}
+	entered, err := prompt.Run()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(entered) == name, nil
 }

--- a/internal/cluster/ui/wizard_steps.go
+++ b/internal/cluster/ui/wizard_steps.go
@@ -177,6 +177,10 @@ func (ws *WizardSteps) ConfirmConfiguration(config models.ClusterConfig) (bool, 
 		}
 	}
 
+	if config.Cloud != nil {
+		pterm.Warning.Println(CostHint(config.Type))
+	}
+
 	// Use pterm for consistent styling
 	if err := renderConfigurationTable(data); err != nil {
 		// Fallback to simple display


### PR DESCRIPTION
- --dry-run for cloud types runs a real terraform plan (plan -out + show): new clusters plan in a throwaway dir without registering; soft-skip when terraform is absent
- apply/destroy stream terraform's -json events as per-resource progress lines (verbose forwards everything); spinner is now k3d-only
- deleting a cloud cluster requires re-typing its name (--force skips; non-interactive without --force refuses)
- opt-in remote state via --backend-config s3://|gcs:// with generated backend.tf, scheme validated per provider
- provider-specific cost warnings in summary and wizard confirm
- ADRs: D5 rewritten (three backends via factory), D7 Terraform/BUSL rationale + verified pinned install, D8 local-state workspace registry