### PR TITLE
chore(cluster): pre-e2e hardening — template validation, tf version gate, docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # OpenFrame CLI Makefile
 
-.PHONY: all build build-all clean test test-unit test-race test-integration lint fmt vet tidy help
+.PHONY: all build build-all clean test test-unit test-race test-integration test-tfvalidate lint fmt vet tidy help
 
 # Variables
 BINARY_NAME := openframe
@@ -49,6 +49,15 @@ test-race: ## Run unit tests with the race detector (requires CGO)
 test-integration: ## Run integration tests (real k3d clusters; needs docker + k3d)
 	@echo "Running integration tests (real clusters!)..."
 	@go test -tags integration -count=1 ./tests/integration/...
+
+# Terraform template validation is opt-in via a build tag: it runs a real
+# `terraform init` (downloads the pinned modules + providers — network, ~min)
+# and `terraform validate` on the generated EKS/GKE root modules. No cloud
+# credentials needed; the strongest pre-e2e check of the templates.
+test-tfvalidate: ## Validate generated terraform templates (needs terraform + network)
+	@echo "Validating terraform templates (downloads providers)..."
+	@go test -tags tfvalidate -count=1 -timeout 15m -run '^TestTerraformValidate$$' \
+		./internal/cluster/providers/eks/... ./internal/cluster/providers/gke/...
 
 test: test-unit test-integration ## Run unit + integration tests
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The bootstrap process creates:
 | Command | Description | Example |
 |---------|-------------|---------|
 | `openframe bootstrap` | Create a cluster and deploy OpenFrame | `openframe bootstrap my-cluster` |
-| `openframe cluster create` | Create a Kubernetes cluster | `openframe cluster create dev --nodes 1` |
+| `openframe cluster create` | Create a k3d or cloud (EKS/GKE) cluster | `openframe cluster create dev --nodes 1` |
 | `openframe cluster list` | List clusters | `openframe cluster list -o json` |
 | `openframe cluster status` | Show cluster status | `openframe cluster status dev` |
 | `openframe cluster delete` | Delete a cluster | `openframe cluster delete dev --force` |
@@ -180,6 +180,7 @@ Cluster lifecycle:
 
 ```bash
 openframe cluster create dev --type k3d --nodes 1 --skip-wizard
+openframe cluster create my-eks --type eks --region us-east-1 --skip-wizard   # cloud (billed!)
 openframe cluster list                          # add -o json|yaml for scripts
 openframe cluster status dev
 openframe cluster delete dev --force

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,12 @@ This repository (`flamingo-stack/openframe-cli`) is the CLI. The platform and ap
 - [Prerequisites](./getting-started/prerequisites.md) — System requirements and dependencies
 - [Quick Start](./getting-started/quick-start.md) — Install and bootstrap in a few minutes
 - [First Steps](./getting-started/first-steps.md) — Core commands and workflows
+- [Cloud Clusters](./getting-started/cloud-clusters.md) — Provision EKS/GKE clusters with Terraform
 
 ## Commands
 
 - `openframe bootstrap` — Create a cluster and install the platform in one step
-- `openframe cluster {create,delete,list,status,cleanup}` — Manage k3d clusters
+- `openframe cluster {create,delete,list,status,cleanup}` — Manage k3d and cloud (EKS/GKE) clusters
 - `openframe app {install,upgrade,status,access,uninstall}` — Manage the OpenFrame app-of-apps deployment
 - `openframe prerequisites {check,install}` — Check and install required tools
 - `openframe update` (`check`, `rollback`, `update <version>`) — Self-update the CLI

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -1,0 +1,98 @@
+# Cloud Clusters (EKS / GKE)
+
+Besides local k3d clusters, `openframe cluster create` can provision managed
+Kubernetes clusters in AWS (EKS) or Google Cloud (GKE) using Terraform under
+the hood. The CLI installs its own verified Terraform binary and generates the
+infrastructure code for you — no Terraform knowledge required.
+
+> **Cost warning.** Cloud clusters create billed resources: a managed control
+> plane (~$73/month on both providers), VM nodes, and NAT/networking. The CLI
+> shows this warning before creating and requires you to re-type the cluster
+> name before deleting.
+
+## Prerequisites
+
+Checked and installed automatically on `cluster create`:
+
+| Type | Tools | You provide |
+|------|-------|-------------|
+| eks  | terraform (pinned, verified), AWS CLI | working AWS credentials (`aws configure` or `--profile`) |
+| gke  | terraform (pinned, verified), gcloud, gke-gcloud-auth-plugin | `gcloud auth login` + a GCP project |
+
+Credentials are preflighted before anything is created (`aws sts
+get-caller-identity` / `gcloud auth print-access-token`), so a broken login
+fails in seconds, not mid-provisioning.
+
+## Creating a cluster
+
+Interactive (wizard asks for type, region, instance type):
+
+```bash
+openframe cluster create
+```
+
+Non-interactive:
+
+```bash
+# AWS EKS
+openframe cluster create my-eks --type eks --region us-east-1 --skip-wizard
+
+# Google GKE
+openframe cluster create my-gke --type gke --project my-project --region us-central1 --skip-wizard
+```
+
+Useful flags: `--machine-type`, `--min-nodes` / `--max-nodes`, `--spot`,
+`--profile` (AWS), `--nodes` (initial size), `--version` (`<major>.<minor>`,
+e.g. `1.33`).
+
+Provisioning takes ~10–20 minutes; the CLI streams per-resource progress.
+When it finishes, your kubeconfig gets a context named after the cluster and
+it becomes the current context — `kubectl get nodes` just works
+(authentication runs through short-lived tokens via `aws eks get-token` /
+`gke-gcloud-auth-plugin`; no static credentials are stored).
+
+## Previewing without creating
+
+`--dry-run` runs a real `terraform plan` and prints the resource footprint
+without creating anything (and without registering the cluster):
+
+```bash
+openframe cluster create my-eks --type eks --region us-east-1 --skip-wizard --dry-run
+# Plan: 47 to add, 0 to change, 0 to destroy
+```
+
+## Where the state lives
+
+Each cloud cluster owns a workspace in `~/.openframe/clusters/<name>/`: the
+generated Terraform module and the state file. The state is the only pointer
+to your billed cloud resources — the workspace is never deleted on a failed
+create, only after a successful delete.
+
+- **A create failed or was interrupted?** Re-run the same `cluster create` —
+  it resumes where it stopped.
+- **Want the state to survive your machine?** Pass a remote backend at
+  create time: `--backend-config s3://bucket/prefix` (EKS) or
+  `--backend-config gcs://bucket/prefix` (GKE).
+
+## Day-2 commands
+
+```bash
+openframe cluster list                # local + cloud clusters
+openframe cluster status my-eks
+openframe cluster delete my-eks       # terraform destroy; asks to re-type the name
+openframe app install                 # install OpenFrame onto the current context
+```
+
+`cluster delete --force` skips the typed confirmation (for CI). `cluster
+cleanup` does not apply to cloud clusters — use `delete`.
+
+## Troubleshooting
+
+- **"AWS ... cannot authenticate" / "gcloud is not authenticated"** — fix
+  credentials (`aws configure`, `gcloud auth login`) and re-run; nothing was
+  created.
+- **Create failed mid-way** — the error names the workspace directory. Re-run
+  `cluster create <name>` to resume, or `cluster delete <name>` to tear down
+  what was partially created.
+- **Verbose Terraform output** — add `--verbose` to stream Terraform's own
+  logs during create/delete.

--- a/internal/cluster/prerequisites/terraform/terraform.go
+++ b/internal/cluster/prerequisites/terraform/terraform.go
@@ -2,9 +2,12 @@ package terraform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/flamingo-stack/openframe-cli/internal/platform"
@@ -28,9 +31,16 @@ func commandExists(cmd string) bool {
 	return err == nil
 }
 
-// IsInstalled reports whether a working terraform binary is reachable. The
-// CLI-managed bin dir is prepended to PATH so a previously installed pinned
-// binary is found even in a fresh shell.
+// Minimum terraform version the generated root modules require
+// (required_version = ">= 1.15.0" in the templates). An older system
+// terraform must count as NOT installed, so the pinned binary gets installed
+// into ~/.openframe/bin — which then wins PATH resolution.
+const minMajor, minMinor = 1, 15
+
+// IsInstalled reports whether a terraform binary that satisfies the
+// templates' version constraint is reachable. The CLI-managed bin dir is
+// prepended to PATH so a previously installed pinned binary is found even in
+// a fresh shell.
 func (t *TerraformInstaller) IsInstalled() bool {
 	if binDir, err := download.UserBinDir(); err == nil {
 		download.PrependToPath(binDir)
@@ -40,7 +50,33 @@ func (t *TerraformInstaller) IsInstalled() bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	return exec.CommandContext(ctx, "terraform", "version").Run() == nil
+	out, err := exec.CommandContext(ctx, "terraform", "version", "-json").Output()
+	if err != nil {
+		return false
+	}
+	var v struct {
+		TerraformVersion string `json:"terraform_version"`
+	}
+	if err := json.Unmarshal(out, &v); err != nil {
+		return false
+	}
+	return versionSatisfies(v.TerraformVersion, minMajor, minMinor)
+}
+
+// versionSatisfies reports whether version ("1.15.8") is >= major.minor.
+// Unparseable versions are treated as too old — the safe direction, since it
+// triggers a pinned install rather than a mid-provisioning failure.
+func versionSatisfies(version string, major, minor int) bool {
+	parts := strings.SplitN(strings.TrimPrefix(version, "v"), ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	gotMajor, err1 := strconv.Atoi(parts[0])
+	gotMinor, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return gotMajor > major || (gotMajor == major && gotMinor >= minor)
 }
 
 func (t *TerraformInstaller) GetInstallHelp() string {

--- a/internal/cluster/prerequisites/terraform/terraform_test.go
+++ b/internal/cluster/prerequisites/terraform/terraform_test.go
@@ -1,0 +1,31 @@
+package terraform
+
+import "testing"
+
+// TestVersionSatisfies locks the terraform version gate: the generated root
+// modules require >= 1.15, so an older system terraform must count as NOT
+// installed (found by a real tfvalidate run against terraform 1.13.3, which
+// passed the old binary-presence check and then failed on required_version).
+func TestVersionSatisfies(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"1.15.0", true},
+		{"1.15.8", true},
+		{"1.16.0", true},
+		{"2.0.0", true},
+		{"v1.15.8", true},
+		{"1.13.3", false},
+		{"1.14.9", false},
+		{"0.15.0", false},
+		{"", false},
+		{"nonsense", false},
+		{"1", false},
+	}
+	for _, tc := range cases {
+		if got := versionSatisfies(tc.version, minMajor, minMinor); got != tc.want {
+			t.Errorf("versionSatisfies(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}

--- a/internal/cluster/providers/eks/template_validate_test.go
+++ b/internal/cluster/providers/eks/template_validate_test.go
@@ -1,0 +1,64 @@
+//go:build tfvalidate
+
+package eks
+
+// Opt-in template validation: `make test-tfvalidate`. Runs a real
+// `terraform init` (downloads the pinned modules + providers, needs network)
+// followed by `terraform validate`, which statically checks the generated
+// root module against the downloaded module schemas — wrong input names or
+// types fail here without any cloud credentials. This is the strongest check
+// available before a real (billed) e2e apply.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestTerraformValidate(t *testing.T) {
+	bin, err := tfengine.FindTerraform()
+	if err != nil {
+		t.Fatalf("the tfvalidate tag requires a terraform binary: %v", err)
+	}
+
+	vars, err := tfvarsFor(models.ClusterConfig{
+		Name:      "validate-only",
+		Type:      models.ClusterTypeEKS,
+		NodeCount: 3,
+		Cloud:     &models.CloudConfig{Region: "us-east-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := tfengine.WriteModule(dir, mainTF, vars); err != nil {
+		t.Fatal(err)
+	}
+
+	tf, err := tfexec.NewTerraform(dir, bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	if err := tf.Init(ctx, tfexec.Upgrade(false)); err != nil {
+		t.Fatalf("terraform init: %v", err)
+	}
+
+	out, err := tf.Validate(ctx)
+	if err != nil {
+		t.Fatalf("terraform validate: %v", err)
+	}
+	for _, d := range out.Diagnostics {
+		t.Logf("%s: %s — %s", d.Severity, d.Summary, d.Detail)
+	}
+	if !out.Valid || out.ErrorCount > 0 {
+		t.Fatalf("EKS template is invalid: %d error(s)", out.ErrorCount)
+	}
+}

--- a/internal/cluster/providers/gke/template_validate_test.go
+++ b/internal/cluster/providers/gke/template_validate_test.go
@@ -1,0 +1,61 @@
+//go:build tfvalidate
+
+package gke
+
+// Opt-in template validation: `make test-tfvalidate`. See the EKS twin for
+// the rationale — this statically verifies the generated root module against
+// the real downloaded module schemas, without cloud credentials.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestTerraformValidate(t *testing.T) {
+	bin, err := tfengine.FindTerraform()
+	if err != nil {
+		t.Fatalf("the tfvalidate tag requires a terraform binary: %v", err)
+	}
+
+	vars, err := tfvarsFor(models.ClusterConfig{
+		Name:      "validate-only",
+		Type:      models.ClusterTypeGKE,
+		NodeCount: 3,
+		Cloud:     &models.CloudConfig{Region: "us-central1", Project: "validate-only"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := tfengine.WriteModule(dir, mainTF, vars); err != nil {
+		t.Fatal(err)
+	}
+
+	tf, err := tfexec.NewTerraform(dir, bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	if err := tf.Init(ctx, tfexec.Upgrade(false)); err != nil {
+		t.Fatalf("terraform init: %v", err)
+	}
+
+	out, err := tf.Validate(ctx)
+	if err != nil {
+		t.Fatalf("terraform validate: %v", err)
+	}
+	for _, d := range out.Diagnostics {
+		t.Logf("%s: %s — %s", d.Severity, d.Summary, d.Detail)
+	}
+	if !out.Valid || out.ErrorCount > 0 {
+		t.Fatalf("GKE template is invalid: %d error(s)", out.ErrorCount)
+	}
+}

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -24,6 +24,12 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// bootstrapNodeCount is the k3d node count for `openframe bootstrap` — one
+// more than `cluster create`'s default of 3 because bootstrap immediately
+// installs the full platform. Kept as a named constant so the discrepancy is
+// a decision, not an accident (audit follow-up).
+const bootstrapNodeCount = 4
+
 // ApplicationCleaner removes the ArgoCD Application CRs that own the platform
 // workloads, and strips the resources-finalizer from any left in Terminating.
 //
@@ -963,12 +969,15 @@ func CreateClusterWithPrerequisitesNonInteractive(ctx context.Context, clusterNa
 		service = NewClusterService(exec)
 	}
 
-	// Build cluster configuration
+	// Build cluster configuration. Bootstrap deliberately uses one node MORE
+	// than `cluster create`'s default of 3: it immediately installs the full
+	// platform (17 ArgoCD apps), which needs the extra headroom — a bare
+	// cluster does not.
 	config := models.ClusterConfig{
 		Name:       clusterName,
 		Type:       models.ClusterTypeK3d,
 		K8sVersion: "",
-		NodeCount:  4,
+		NodeCount:  bootstrapNodeCount,
 	}
 	if clusterName == "" {
 		config.Name = "openframe-dev" // default name

--- a/internal/shared/config/transport_test.go
+++ b/internal/shared/config/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestIsLocalAPIServer(t *testing.T) {
@@ -57,6 +58,33 @@ func TestApplyInsecureTLSConfig_BypassesLocalOnly(t *testing.T) {
 	}
 	if string(rem.CAData) != "ca" {
 		t.Error("remote cluster: CA must be preserved")
+	}
+}
+
+// TestApplyInsecureTLSConfig_CloudExecConfigsUntouched locks the cloud-cluster
+// guarantee: EKS/GKE rest.Configs (public endpoint + CA + exec-plugin auth)
+// pass through the chart subsystem's "defense-in-depth" insecure wraps without
+// any TLS downgrade — the local-only guard must keep covering them.
+func TestApplyInsecureTLSConfig_CloudExecConfigsUntouched(t *testing.T) {
+	hosts := []string{
+		"https://ABCDEF123.gr7.us-east-1.eks.amazonaws.com", // EKS
+		"https://34.10.20.30",                               // GKE (bare public IP)
+	}
+	for _, host := range hosts {
+		cfg := ApplyInsecureTLSConfig(&rest.Config{
+			Host:            host,
+			TLSClientConfig: rest.TLSClientConfig{CAData: []byte("ca")},
+			ExecProvider:    &clientcmdapi.ExecConfig{Command: "aws"},
+		})
+		if cfg.Insecure {
+			t.Errorf("%s: TLS must NOT be bypassed for a cloud endpoint", host)
+		}
+		if string(cfg.CAData) != "ca" {
+			t.Errorf("%s: CA must be preserved for a cloud endpoint", host)
+		}
+		if cfg.ExecProvider == nil {
+			t.Errorf("%s: exec auth must be preserved", host)
+		}
 	}
 }
 


### PR DESCRIPTION
- make test-tfvalidate (tag tfvalidate): real terraform init+validate of the generated EKS/GKE root modules, no cloud credentials; both templates pass on terraform 1.15.8
- prerequisite gate now requires terraform >= 1.15 (templates' required_version): an older system binary triggers the pinned install instead of a mid-provisioning failure
- regression test: cloud rest.Configs (public endpoint + exec auth) pass the insecure-TLS wraps untouched (B5 local-only guard)
- docs: getting-started/cloud-clusters.md + README/index links
- bootstrap's 4-node count is a documented constant vs create's default 3