### PR TITLE
fix(ci): failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/elastic/go-sysinfo v1.15.5
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/hashicorp/terraform-exec v0.25.2
+	github.com/hashicorp/terraform-json v0.27.2
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pterm/pterm v0.12.83
 	github.com/sigstore/sigstore-go v1.2.2
@@ -83,7 +84,6 @@ require (
 	github.com/gookit/color v1.6.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
-	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/cluster/prerequisites/checker.go
+++ b/internal/cluster/prerequisites/checker.go
@@ -134,18 +134,31 @@ func CheckPrerequisites() error {
 	return NewInstaller().CheckAndInstallNonInteractive(ui.IsNonInteractive())
 }
 
-// CheckForClusterType runs the prerequisite gate for the given cluster type:
+// checkerForClusterType returns the requirement set for a cluster type:
 // Docker/k3d/helm for local k3d clusters, terraform + the cloud CLI for the
-// cloud types. Unknown types pass through and fail at the provider factory.
-func CheckForClusterType(clusterType models.ClusterType) error {
+// cloud types. Unknown types return nil — they pass the gate and fail at the
+// provider factory instead. Pure dispatch (no checks, no installs), so tests
+// can verify the mapping without touching the machine.
+func checkerForClusterType(clusterType models.ClusterType) *PrerequisiteChecker {
 	switch clusterType {
 	case models.ClusterTypeK3d, "":
-		return CheckPrerequisites()
+		return NewPrerequisiteChecker()
 	case models.ClusterTypeEKS:
-		return NewInstallerWithChecker(NewEKSPrerequisiteChecker()).CheckAndInstallNonInteractive(ui.IsNonInteractive())
+		return NewEKSPrerequisiteChecker()
 	case models.ClusterTypeGKE:
-		return NewInstallerWithChecker(NewGKEPrerequisiteChecker()).CheckAndInstallNonInteractive(ui.IsNonInteractive())
+		return NewGKEPrerequisiteChecker()
 	default:
 		return nil
 	}
+}
+
+// CheckForClusterType runs the prerequisite gate for the given cluster type,
+// installing missing tools (auto-approved when non-interactive).
+func CheckForClusterType(clusterType models.ClusterType) error {
+	checker := checkerForClusterType(clusterType)
+	if checker == nil {
+		return nil
+	}
+	// A CI environment or a non-terminal stdin must not hit an interactive prompt.
+	return NewInstallerWithChecker(checker).CheckAndInstallNonInteractive(ui.IsNonInteractive())
 }

--- a/internal/cluster/prerequisites/checker_test.go
+++ b/internal/cluster/prerequisites/checker_test.go
@@ -83,13 +83,54 @@ func containsAny(str string, substrings []string) bool {
 	return false
 }
 
-func TestCheckForClusterType_CloudTypesSkipLocalGate(t *testing.T) {
-	// The Docker/k3d/helm gate is for local clusters only; cloud types must
-	// pass through regardless of what is installed on this machine.
-	for _, clusterType := range []models.ClusterType{models.ClusterTypeGKE, models.ClusterTypeEKS} {
-		if err := CheckForClusterType(clusterType); err != nil {
-			t.Errorf("CheckForClusterType(%s) should not require local tools: %v", clusterType, err)
+// TestCheckerForClusterType verifies the type→requirements dispatch WITHOUT
+// invoking CheckForClusterType: that function runs real installers in
+// non-interactive mode, and an earlier version of this test did exactly that —
+// it downloaded terraform onto CI runners and failed on `gcloud components
+// install` (CI regression). Only the pure mapping is unit-testable.
+func TestCheckerForClusterType(t *testing.T) {
+	names := func(c *PrerequisiteChecker) []string {
+		var out []string
+		for _, r := range c.requirements {
+			out = append(out, r.Name)
 		}
+		return out
+	}
+
+	cases := []struct {
+		clusterType models.ClusterType
+		want        []string
+	}{
+		{models.ClusterTypeK3d, []string{"Docker", "k3d", "helm"}},
+		{models.ClusterType(""), []string{"Docker", "k3d", "helm"}},
+		{models.ClusterTypeEKS, []string{"terraform", "AWS CLI"}},
+		{models.ClusterTypeGKE, []string{"terraform", "gcloud", "gke-gcloud-auth-plugin"}},
+	}
+	for _, tc := range cases {
+		checker := checkerForClusterType(tc.clusterType)
+		if checker == nil {
+			t.Fatalf("checkerForClusterType(%q) = nil, want a requirement set", tc.clusterType)
+		}
+		got := names(checker)
+		if len(got) != len(tc.want) {
+			t.Fatalf("checkerForClusterType(%q) = %v, want %v", tc.clusterType, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("checkerForClusterType(%q)[%d] = %s, want %s", tc.clusterType, i, got[i], tc.want[i])
+			}
+		}
+		// Every requirement must be fully wired — a nil func would panic the
+		// installer flow at runtime.
+		for _, r := range checker.requirements {
+			if r.IsInstalled == nil || r.Install == nil || r.InstallHelp == nil {
+				t.Errorf("%s/%s: requirement funcs must all be set", tc.clusterType, r.Name)
+			}
+		}
+	}
+
+	if checkerForClusterType("unknown") != nil {
+		t.Error("unknown types must return nil (gate passes, provider factory rejects)")
 	}
 }
 

--- a/internal/cluster/prerequisites/docker/docker_test.go
+++ b/internal/cluster/prerequisites/docker/docker_test.go
@@ -37,48 +37,29 @@ func TestDockerInstaller_GetInstallHelp(t *testing.T) {
 	}
 }
 
+// TestDockerInstaller_Install only exercises the fail-fast error paths. It
+// must NEVER call Install() where the real install could proceed: on CI
+// runners with Homebrew this test used to run an actual
+// `brew install --cask docker-desktop` (~100s, mutating the runner and
+// failing on brew's own errors).
 func TestDockerInstaller_Install(t *testing.T) {
-	installer := NewDockerInstaller()
-
-	// We can't actually test installation in CI, but we can test error handling
-	err := installer.Install()
-
-	// On unsupported platforms, should return specific error
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-		expectedPrefix := "automatic Docker installation not supported on"
-		if err == nil || !containsSubstring(err.Error(), expectedPrefix) {
-			t.Errorf("Expected error containing '%s', got: %v", expectedPrefix, err)
-		}
-		return
+	if runtime.GOOS == "darwin" && commandExists("brew") {
+		t.Skip("would run a real 'brew install --cask docker-desktop'")
 	}
-
-	// On macOS without brew, should suggest installing brew
-	if runtime.GOOS == "darwin" && !commandExists("brew") {
-		if err == nil {
-			t.Error("Expected error when Homebrew is not installed")
-		} else {
-			expectedSubstring := "Homebrew is required"
-			if !containsSubstring(err.Error(), expectedSubstring) {
-				t.Errorf("Expected error containing '%s', got: %v", expectedSubstring, err)
-			}
-		}
-		return
+	if runtime.GOOS == "linux" {
+		t.Skip("would run a real package-manager install")
 	}
-
-	// On Linux without sudo or package managers, should fail
-	if runtime.GOOS == "linux" && !commandExists("sudo") {
-		if err != nil {
-			// This is expected, installation needs sudo
-			return
-		}
-	}
-
-	// On Windows, may attempt WSL setup (will likely fail in test environment)
-	// Just verify it doesn't panic and returns some result
 	if runtime.GOOS == "windows" {
-		// Windows installation will likely fail due to WSL not being set up in tests
-		// We just verify the function runs without panicking
-		_ = err
+		t.Skip("would attempt a real WSL setup")
+	}
+
+	// Only the guaranteed-error path remains: darwin without Homebrew.
+	err := NewDockerInstaller().Install()
+	if err == nil {
+		t.Fatal("expected an error when no install tooling is available")
+	}
+	if !containsSubstring(err.Error(), "Homebrew is required") {
+		t.Errorf("expected a Homebrew hint, got: %v", err)
 	}
 }
 

--- a/internal/cluster/prerequisites/k3d/k3d_test.go
+++ b/internal/cluster/prerequisites/k3d/k3d_test.go
@@ -39,37 +39,29 @@ func TestK3dInstaller_GetInstallHelp(t *testing.T) {
 	}
 }
 
+// TestK3dInstaller_Install only exercises the fail-fast error paths. It must
+// NEVER call Install() where the real install could proceed: on CI runners
+// this test used to run a real `brew install k3d` (darwin) or download the
+// pinned binary into the runner's ~/.openframe/bin (linux).
 func TestK3dInstaller_Install(t *testing.T) {
-	installer := NewK3dInstaller()
-
-	// We can't actually test installation in CI, but we can test error handling
-	err := installer.Install()
-
-	// On unsupported platforms, should return specific error
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-		expectedPrefix := "automatic k3d installation not supported on"
-		if err == nil || !containsSubstring(err.Error(), expectedPrefix) {
-			t.Errorf("Expected error containing '%s', got: %v", expectedPrefix, err)
-		}
-		return
+	if runtime.GOOS == "darwin" && commandExists("brew") {
+		t.Skip("would run a real 'brew install k3d'")
+	}
+	if runtime.GOOS == "linux" {
+		t.Skip("would run a real package-manager install or verified download")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("k3d installs via WSL on windows")
 	}
 
-	// On macOS without brew, should suggest installing brew
-	if runtime.GOOS == "darwin" && !commandExists("brew") {
-		if err == nil {
-			t.Error("Expected error when Homebrew is not installed")
-		} else {
-			expectedSubstring := "Homebrew is required"
-			if !containsSubstring(err.Error(), expectedSubstring) {
-				t.Errorf("Expected error containing '%s', got: %v", expectedSubstring, err)
-			}
-		}
-		return
+	// Only the guaranteed-error path remains: darwin without Homebrew.
+	err := NewK3dInstaller().Install()
+	if err == nil {
+		t.Fatal("expected an error when no install tooling is available")
 	}
-
-	// On Linux and Windows, the installation will likely fail in test environments
-	// We just verify the function runs without panicking
-	_ = err
+	if !containsSubstring(err.Error(), "Homebrew") {
+		t.Errorf("expected a Homebrew hint, got: %v", err)
+	}
 }
 
 func TestCommandExists(t *testing.T) {

--- a/internal/cluster/prerequisites/terraform/terraform.go
+++ b/internal/cluster/prerequisites/terraform/terraform.go
@@ -84,14 +84,14 @@ func (t *TerraformInstaller) GetInstallHelp() string {
 }
 
 // Install downloads the pinned Terraform release, verifies its SHA256, and
-// installs it into ~/.openframe/bin (no sudo).
+// installs it into ~/.openframe/bin (no sudo). Unlike docker/k3d (which run
+// inside WSL on Windows), terraform is installed natively on all three
+// platforms — the provisioning engine invokes it directly.
 func (t *TerraformInstaller) Install() error {
 	switch runtime.GOOS {
-	case "darwin", "linux":
+	case "darwin", "linux", "windows":
 		return t.installVerified()
 	default:
-		// Windows is unsupported here by design: the CLI forwards into WSL and
-		// runs as linux, so native-Windows install code is never reached.
 		return fmt.Errorf("automatic terraform installation not supported on %s", runtime.GOOS)
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -87,7 +87,7 @@ var toolDocs = map[string]InstallDocs{
 	"terraform": {
 		Darwin:  "terraform: A verified pinned binary is installed automatically to ~/.openframe/bin, or download from https://developer.hashicorp.com/terraform/install",
 		Linux:   "terraform: A verified pinned binary is installed automatically to ~/.openframe/bin, or download from https://developer.hashicorp.com/terraform/install",
-		Windows: "terraform: Download from https://developer.hashicorp.com/terraform/install",
+		Windows: "terraform: A verified pinned binary is installed automatically to ~/.openframe/bin, or download from https://developer.hashicorp.com/terraform/install",
 		Default: "terraform: Please install terraform from https://developer.hashicorp.com/terraform/install",
 	},
 	"gcloud": {

--- a/internal/shared/download/pins.go
+++ b/internal/shared/download/pins.go
@@ -96,16 +96,20 @@ var Helm = PinnedTool{
 
 // Terraform is the pinned Terraform CLI, used by the cloud cluster providers
 // (EKS/GKE). Upstream: https://releases.hashicorp.com/terraform/ — assets are
-// .zip archives with the bare "terraform" binary inside; SHA256 from the
-// release's SHA256SUMS file.
+// .zip archives with the bare terraform binary (terraform.exe on Windows)
+// inside; SHA256 from the release's SHA256SUMS file. Unlike k3d/helm (which
+// run inside WSL on Windows), terraform is pinned for Windows too: the
+// provisioning engine runs it natively.
 const (
 	terraformVersion = "1.15.8"
 	terraformBaseURL = "https://releases.hashicorp.com/terraform/" + terraformVersion + "/terraform_" + terraformVersion + "_"
 
-	terraformSHA256LinuxAMD64  = "d25ce7b6902013ad905db3d2eab0be4cd905887fe88b81a6171b8d5503c31f3d"
-	terraformSHA256LinuxARM64  = "8891e9dcedc9e3b8950bc6af9d4d8af1f4cfade3062f53b9dc403a89f6ce8c9c"
-	terraformSHA256DarwinAMD64 = "e2e812e783771159bf758fd4e55d6dc9bb08f63e2af2c63d212721807a02c5dc"
-	terraformSHA256DarwinARM64 = "f210110c5698b94d803a7a63cdb0251b5455c150841478808e2bbb343f95ed68"
+	terraformSHA256LinuxAMD64   = "d25ce7b6902013ad905db3d2eab0be4cd905887fe88b81a6171b8d5503c31f3d"
+	terraformSHA256LinuxARM64   = "8891e9dcedc9e3b8950bc6af9d4d8af1f4cfade3062f53b9dc403a89f6ce8c9c"
+	terraformSHA256DarwinAMD64  = "e2e812e783771159bf758fd4e55d6dc9bb08f63e2af2c63d212721807a02c5dc"
+	terraformSHA256DarwinARM64  = "f210110c5698b94d803a7a63cdb0251b5455c150841478808e2bbb343f95ed68"
+	terraformSHA256WindowsAMD64 = "2ff41d2129afb1982733c132c61a8d6ef038f879f3aeede7fc28b8b8b24acf02"
+	terraformSHA256WindowsARM64 = "ffd9399a37ee8123263d84ec5c00d09d7704f9997cb345d7c9cac56c3fc1348e"
 )
 
 var Terraform = PinnedTool{
@@ -113,10 +117,12 @@ var Terraform = PinnedTool{
 	Version: terraformVersion,
 	Zip:     true,
 	Assets: map[string]PinnedAsset{
-		"linux/amd64":  {URL: terraformBaseURL + "linux_amd64.zip", SHA256: terraformSHA256LinuxAMD64},
-		"linux/arm64":  {URL: terraformBaseURL + "linux_arm64.zip", SHA256: terraformSHA256LinuxARM64},
-		"darwin/amd64": {URL: terraformBaseURL + "darwin_amd64.zip", SHA256: terraformSHA256DarwinAMD64},
-		"darwin/arm64": {URL: terraformBaseURL + "darwin_arm64.zip", SHA256: terraformSHA256DarwinARM64},
+		"linux/amd64":   {URL: terraformBaseURL + "linux_amd64.zip", SHA256: terraformSHA256LinuxAMD64},
+		"linux/arm64":   {URL: terraformBaseURL + "linux_arm64.zip", SHA256: terraformSHA256LinuxARM64},
+		"darwin/amd64":  {URL: terraformBaseURL + "darwin_amd64.zip", SHA256: terraformSHA256DarwinAMD64},
+		"darwin/arm64":  {URL: terraformBaseURL + "darwin_arm64.zip", SHA256: terraformSHA256DarwinARM64},
+		"windows/amd64": {URL: terraformBaseURL + "windows_amd64.zip", SHA256: terraformSHA256WindowsAMD64},
+		"windows/arm64": {URL: terraformBaseURL + "windows_arm64.zip", SHA256: terraformSHA256WindowsARM64},
 	},
 }
 
@@ -142,7 +148,7 @@ func (d Downloader) InstallPinnedTool(ctx context.Context, tool PinnedTool, binD
 	if err := os.MkdirAll(binDir, 0o750); err != nil {
 		return "", fmt.Errorf("creating %s: %w", binDir, err)
 	}
-	dest := filepath.Join(binDir, tool.Name)
+	dest := filepath.Join(binDir, exeName(tool.Name))
 	if tool.Tarball {
 		member := fmt.Sprintf("%s-%s/%s", runtime.GOOS, runtime.GOARCH, tool.Name)
 		if err := d.InstallVerifiedTarGz(ctx, asset, member, dest, 0o750); err != nil {
@@ -151,7 +157,7 @@ func (d Downloader) InstallPinnedTool(ctx context.Context, tool PinnedTool, binD
 		return dest, nil
 	}
 	if tool.Zip {
-		if err := d.InstallVerifiedZipMember(ctx, asset, tool.Name, dest, 0o750); err != nil {
+		if err := d.InstallVerifiedZipMember(ctx, asset, exeName(tool.Name), dest, 0o750); err != nil {
 			return "", err
 		}
 		return dest, nil
@@ -160,6 +166,16 @@ func (d Downloader) InstallPinnedTool(ctx context.Context, tool PinnedTool, binD
 		return "", err
 	}
 	return dest, nil
+}
+
+// exeName appends the Windows executable suffix where the OS requires it —
+// archive members and installed binaries are named tool.exe on Windows
+// (e.g. terraform.exe inside HashiCorp's windows zips).
+func exeName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
 }
 
 // PrependToPath puts dir at the front of the current process PATH when it is

--- a/internal/shared/download/pins_test.go
+++ b/internal/shared/download/pins_test.go
@@ -1,6 +1,8 @@
 package download
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -140,10 +142,13 @@ func TestPinnedAssets_RealDownload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("network test skipped under -short")
 	}
-	if runtime.GOOS == "windows" {
-		t.Skip("no windows pins: on Windows the CLI runs the linux binary inside WSL")
+	tools := []PinnedTool{Terraform}
+	if runtime.GOOS != "windows" {
+		// k3d/mkcert/helm have no windows pins: on Windows they run inside WSL.
+		// Terraform is pinned for all platforms.
+		tools = append(tools, K3d, Mkcert, Helm)
 	}
-	for _, tool := range []PinnedTool{K3d, Mkcert, Helm} {
+	for _, tool := range tools {
 		asset, ok := tool.Asset(runtime.GOOS, runtime.GOARCH)
 		if !ok {
 			t.Errorf("%s: no asset for %s/%s", tool.Name, runtime.GOOS, runtime.GOARCH)
@@ -178,6 +183,82 @@ func TestHelm_Pins(t *testing.T) {
 		if !strings.Contains(asset.URL, Helm.Version) || !strings.HasSuffix(asset.URL, p.os+"-"+p.arch+".tar.gz") {
 			t.Errorf("%s/%s: URL %q must contain version and end with platform.tar.gz", p.os, p.arch, asset.URL)
 		}
+	}
+}
+
+// TestTerraform_Pins locks the terraform pin shape: a versioned .zip +
+// non-empty SHA256 for every supported platform — including Windows, where
+// terraform (unlike k3d/helm) runs natively rather than inside WSL.
+func TestTerraform_Pins(t *testing.T) {
+	if Terraform.Version == "" {
+		t.Fatal("Terraform.Version must be set")
+	}
+	if !Terraform.Zip {
+		t.Error("Terraform assets are .zip — Zip must be true")
+	}
+	for _, p := range []struct{ os, arch string }{
+		{"linux", "amd64"}, {"linux", "arm64"},
+		{"darwin", "amd64"}, {"darwin", "arm64"},
+		{"windows", "amd64"}, {"windows", "arm64"},
+	} {
+		asset, ok := Terraform.Asset(p.os, p.arch)
+		if !ok {
+			t.Errorf("no terraform asset for %s/%s", p.os, p.arch)
+			continue
+		}
+		if len(asset.SHA256) != 64 {
+			t.Errorf("%s/%s: SHA256 must be 64 hex chars, got %q", p.os, p.arch, asset.SHA256)
+		}
+		if !strings.Contains(asset.URL, Terraform.Version) || !strings.HasSuffix(asset.URL, p.os+"_"+p.arch+".zip") {
+			t.Errorf("%s/%s: URL %q must contain version and end with platform.zip", p.os, p.arch, asset.URL)
+		}
+	}
+}
+
+// TestInstallPinnedTool_ZipTool covers the .zip install path (terraform's
+// asset format): the binary is extracted from the archive root by name.
+func TestInstallPinnedTool_ZipTool(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file modes (0750) aren't honoured on Windows")
+	}
+	payload := []byte("#!/bin/sh\necho tf\n")
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("faketool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archive := buf.Bytes()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	tool := PinnedTool{
+		Name:    "faketool",
+		Version: "v1.2.3",
+		Zip:     true,
+		Assets:  map[string]PinnedAsset{platformKey(): {URL: srv.URL, SHA256: hexSum(archive)}},
+	}
+	binDir := t.TempDir()
+
+	path, err := (Downloader{Client: srv.Client()}).InstallPinnedTool(context.Background(), tool, binDir)
+	if err != nil {
+		t.Fatalf("InstallPinnedTool(zip): %v", err)
+	}
+	got, err := os.ReadFile(path) // #nosec G304 -- test reads a path it just created under t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("installed content = %q, want %q", got, payload)
 	}
 }
 


### PR DESCRIPTION
1. stop prerequisite test from running real installers; tidy go mod

- TestCheckForClusterType_CloudTypesSkipLocalGate predated the cloud prerequisite sets and now triggered real non-interactive installs on CI runners (downloaded terraform, failed on gcloud components install on all three platforms). Split the pure type→requirements dispatch into checkerForClusterType and test the mapping hermetically.
- go mod tidy: terraform-json became a direct dependency in the plan-summary work but was still marked indirect

2. stop docker/k3d installer tests from running real installs

TestDockerInstaller_Install and TestK3dInstaller_Install called the real
Install(): on CI runners with Homebrew that executed an actual
`brew install --cask docker-desktop` (~100s, failing on brew's own errors)
and `brew install k3d`; on linux, real package-manager attempts and a
pinned-binary download into the runner's ~/.openframe/bin. The tests now
skip wherever a real install could proceed and only assert the guaranteed
fail-fast path (no Homebrew → actionable error).

3. feat(prerequisites): auto-install terraform on Windows via pinned zip

- pin terraform 1.15.8 windows_amd64 + windows_arm64 (SHA256 from the
  release's SHA256SUMS); terraform runs natively on Windows, unlike
  k3d/helm which run inside WSL
- zip member and installed binary are named terraform.exe on Windows
  (new exeName helper in the download package)
- TerraformInstaller.Install supports windows; install hint updated
- tests: terraform pin shape (all 6 platforms), zip install path unit
  test, real-download check now covers terraform on Windows runners