### PR TITLE
feat(cluster): GKE ownership boundary, external discovery, EKS coming-soon gate

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -107,6 +107,16 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 	return nil
 }
 
+// showEKSComingSoonBanner is the temporary stub for AWS EKS creation.
+func showEKSComingSoonBanner() {
+	pterm.DefaultBox.
+		WithTitle(" 🚧 AWS EKS — coming soon ").
+		WithTitleTopCenter().
+		Println("Creating AWS EKS clusters will be available shortly.\n" +
+			"GKE is fully supported today:\n" +
+			"  openframe cluster create my-gke --type gke --project <project> --region <region>")
+}
+
 func runCreateCluster(cmd *cobra.Command, args []string) error {
 	service := utils.GetCommandService()
 	globalFlags := utils.GetGlobalFlags()
@@ -183,6 +193,15 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 				BackendConfig: cf.BackendConfig,
 			}
 		}
+	}
+
+	// AWS EKS creation is temporarily gated behind a coming-soon banner while
+	// the GKE flow is being finished end-to-end. The EKS provider stays fully
+	// functional for existing clusters (status/delete/resume) — only NEW
+	// creates are gated.
+	if config.Type == models.ClusterTypeEKS {
+		showEKSComingSoonBanner()
+		return nil
 	}
 
 	// Show configuration summary for dry-run or skip-wizard modes

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -74,37 +74,35 @@ func TestRunCreateCluster_DryRunDefaultsNameWhenNoArgs(t *testing.T) {
 	}
 }
 
+// While EKS creation is gated behind the coming-soon banner, the plan preview
+// is a GKE-only path (see TestRunCreateCluster_EKSShowsComingSoonBanner).
 func TestRunCreateCluster_CloudDryRunRunsPlanPreview(t *testing.T) {
-	for _, clusterType := range []string{"eks", "gke"} {
-		t.Run(clusterType, func(t *testing.T) {
-			setupCreate(t)
-			// Stub the preview: the real one shells out to terraform.
-			var previewed *models.ClusterConfig
-			orig := planPreviewFn
-			planPreviewFn = func(ctx context.Context, config models.ClusterConfig) error {
-				previewed = &config
-				return nil
-			}
-			t.Cleanup(func() { planPreviewFn = orig })
+	setupCreate(t)
+	// Stub the preview: the real one shells out to terraform.
+	var previewed *models.ClusterConfig
+	orig := planPreviewFn
+	planPreviewFn = func(ctx context.Context, config models.ClusterConfig) error {
+		previewed = &config
+		return nil
+	}
+	t.Cleanup(func() { planPreviewFn = orig })
 
-			cmd := getCreateCmd()
-			gf := utils.GetGlobalFlags()
-			gf.Create.SkipWizard = true
-			gf.Create.DryRun = true
-			gf.Create.ClusterType = clusterType
-			gf.Create.Region = "us-east-1"
-			gf.Create.Project = "my-project"
+	cmd := getCreateCmd()
+	gf := utils.GetGlobalFlags()
+	gf.Create.SkipWizard = true
+	gf.Create.DryRun = true
+	gf.Create.ClusterType = "gke"
+	gf.Create.Region = "us-central1"
+	gf.Create.Project = "my-project"
 
-			if err := runCreateCluster(cmd, []string{"cloud-cluster"}); err != nil {
-				t.Fatalf("%s dry-run should return nil, got %v", clusterType, err)
-			}
-			if previewed == nil {
-				t.Fatal("cloud dry-run must invoke the terraform plan preview")
-			}
-			if previewed.Cloud == nil || previewed.Cloud.Region != "us-east-1" {
-				t.Fatalf("preview received wrong config: %+v", previewed)
-			}
-		})
+	if err := runCreateCluster(cmd, []string{"cloud-cluster"}); err != nil {
+		t.Fatalf("gke dry-run should return nil, got %v", err)
+	}
+	if previewed == nil {
+		t.Fatal("gke dry-run must invoke the terraform plan preview")
+	}
+	if previewed.Cloud == nil || previewed.Cloud.Region != "us-central1" {
+		t.Fatalf("preview received wrong config: %+v", previewed)
 	}
 }
 
@@ -158,5 +156,31 @@ func TestRunClusterStatus_ListFailureSurfacesError(t *testing.T) {
 
 	if err := runClusterStatus(getStatusCmd(), []string{"c1"}); err == nil {
 		t.Fatal("expected an error when cluster listing fails")
+	}
+}
+
+// TestRunCreateCluster_EKSShowsComingSoonBanner: while EKS creation is gated,
+// --type eks must show the banner and exit cleanly — no prerequisite gate, no
+// provider calls, no validation errors about missing --region.
+func TestRunCreateCluster_EKSShowsComingSoonBanner(t *testing.T) {
+	setupCreate(t)
+	called := false
+	orig := planPreviewFn
+	planPreviewFn = func(ctx context.Context, config models.ClusterConfig) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { planPreviewFn = orig })
+
+	cmd := getCreateCmd()
+	gf := utils.GetGlobalFlags()
+	gf.Create.SkipWizard = true
+	gf.Create.ClusterType = "eks"
+
+	if err := runCreateCluster(cmd, []string{"cloud-cluster"}); err != nil {
+		t.Fatalf("eks banner path must return nil, got %v", err)
+	}
+	if called {
+		t.Fatal("eks must not reach the plan preview while gated")
 	}
 }

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -1,11 +1,14 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
@@ -22,8 +25,13 @@ func getListCmd() *cobra.Command {
 Displays cluster information including name, type, status, and node count
 from all registered providers in a formatted table.
 
+With --all, additionally discovers GKE clusters that exist in the GCP
+projects of your gcloud configurations but were created outside openframe.
+Discovered clusters are read-only: openframe never modifies or deletes them.
+
 Examples:
   openframe cluster list
+  openframe cluster list --all
   openframe cluster list --verbose
   openframe cluster list --quiet`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -52,11 +60,19 @@ Examples:
 
 func runListClusters(cmd *cobra.Command, args []string) error {
 	service := utils.GetCommandService()
+	globalFlags := utils.GetGlobalFlags()
 
 	// Get all clusters
 	clusters, err := service.ListClusters()
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var notices []string
+	if globalFlags.List.All {
+		external, discoveryNotices := discoverExternalClusters(cmd.Context(), clusters)
+		clusters = append(clusters, external...)
+		notices = discoveryNotices
 	}
 
 	switch out, _ := cmd.Flags().GetString("output"); out {
@@ -65,11 +81,56 @@ func runListClusters(cmd *cobra.Command, args []string) error {
 	case "yaml":
 		return printClustersYAML(clusters)
 	case "", "text":
-		globalFlags := utils.GetGlobalFlags()
-		return service.DisplayClusterList(clusters, globalFlags.List.Quiet, globalFlags.Global.Verbose)
+		if err := service.DisplayClusterList(clusters, globalFlags.List.Quiet, globalFlags.Global.Verbose); err != nil {
+			return err
+		}
+		for _, notice := range notices {
+			pterm.Info.Println(notice)
+		}
+		return nil
 	default:
 		return fmt.Errorf("invalid --output %q (want \"text\", \"json\", or \"yaml\")", out)
 	}
+}
+
+// discoverExternalClusters runs GKE discovery, dropping entries that are
+// already managed (same name+project as a registry cluster). Auth problems
+// degrade to notices, never errors: a logged-out gcloud must not break list.
+// EKS discovery is not implemented yet — a notice says so.
+func discoverExternalClusters(ctx context.Context, managed []models.ClusterInfo) ([]models.ClusterInfo, []string) {
+	notices := []string{"AWS EKS discovery is coming soon — external EKS clusters are not shown yet"}
+
+	d := discovery.NewGKEDiscoverer(utils.CommandExecutor())
+	switch d.AuthStatus(ctx) {
+	case discovery.CLIMissing:
+		return nil, append(notices, "GKE: gcloud is not installed — install it to discover external clusters")
+	case discovery.NotAuthenticated:
+		return nil, append(notices, "GKE: not authenticated — run 'gcloud auth login' to discover external clusters")
+	}
+
+	result, err := d.Discover(ctx)
+	if err != nil {
+		return nil, append(notices, fmt.Sprintf("GKE discovery failed: %v", err))
+	}
+	for _, w := range result.Warnings {
+		notices = append(notices, "GKE discovery skipped "+w)
+	}
+
+	isManaged := func(c models.ClusterInfo) bool {
+		for _, m := range managed {
+			if m.Name == c.Name && (m.Project == "" || m.Project == c.Project) {
+				return true
+			}
+		}
+		return false
+	}
+	var external []models.ClusterInfo
+	for _, c := range result.Clusters {
+		if !isManaged(c) {
+			external = append(external, c)
+		}
+	}
+	return external, notices
 }
 
 // clusterJSON is the machine-readable shape of a cluster.

--- a/cmd/cluster/list_test.go
+++ b/cmd/cluster/list_test.go
@@ -1,9 +1,11 @@
 package cluster
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
 )
 
@@ -20,4 +22,54 @@ func TestListCommand(t *testing.T) {
 	}
 
 	testutil.TestClusterCommand(t, "list", getListCmd, setupFunc, teardownFunc)
+}
+
+// TestRunListClusters_AllDiscoversExternalGKE drives list --all end to end on
+// mocks: k3d listing + gcloud discovery, with the EKS coming-soon notice.
+func TestRunListClusters_AllDiscoversExternalGKE(t *testing.T) {
+	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "kubeconfig"))
+	utils.InitGlobalFlags()
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("k3d cluster list", &executor.CommandResult{ExitCode: 0, Stdout: "[]"})
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "dev@example.com\n"})
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"dev-x","properties":{"core":{"project":"proj-x"}}}]`})
+	mock.SetResponse("clusters list --project proj-x", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"ext-1","location":"us-central1","status":"RUNNING","currentNodeCount":2}]`})
+	utils.SetTestExecutor(mock)
+	t.Cleanup(utils.ResetGlobalFlags)
+
+	cmd := getListCmd()
+	utils.GetGlobalFlags().List.All = true
+
+	if err := runListClusters(cmd, nil); err != nil {
+		t.Fatalf("list --all: %v", err)
+	}
+	// The discovery call chain must have run.
+	if !mock.WasCommandExecuted("clusters list --project proj-x") {
+		t.Fatal("expected GKE discovery to list clusters in configured projects")
+	}
+}
+
+// TestRunListClusters_AllNotAuthenticatedDegradesGracefully: a logged-out
+// gcloud must not fail the command.
+func TestRunListClusters_AllNotAuthenticatedDegradesGracefully(t *testing.T) {
+	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
+	utils.InitGlobalFlags()
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("k3d cluster list", &executor.CommandResult{ExitCode: 0, Stdout: "[]"})
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: ""})
+	utils.SetTestExecutor(mock)
+	t.Cleanup(utils.ResetGlobalFlags)
+
+	cmd := getListCmd()
+	utils.GetGlobalFlags().List.All = true
+
+	if err := runListClusters(cmd, nil); err != nil {
+		t.Fatalf("list --all without auth must degrade to a notice, got: %v", err)
+	}
+	if mock.WasCommandExecuted("clusters list --project") {
+		t.Fatal("discovery must not query projects when not authenticated")
+	}
 }

--- a/internal/cluster/discovery/gke.go
+++ b/internal/cluster/discovery/gke.go
@@ -1,0 +1,195 @@
+// Package discovery finds cloud Kubernetes clusters that exist OUTSIDE the
+// openframe workspace registry — clusters created by Terraform repos, other
+// tools, or other people. Discovered clusters are strictly read-only for the
+// CLI: they appear in `cluster list --all` and `cluster status`, and every
+// mutating command refuses them (no workspace = not ours).
+//
+// Discovery never stores credentials: it delegates to the provider CLIs
+// (gcloud) through the shared CommandExecutor, so it is fully mockable and
+// respects whatever the user has authenticated.
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// AuthStatus reports whether a provider's CLI is usable without treating
+// "not logged in" as an error — list must degrade gracefully.
+type AuthStatus int
+
+const (
+	Authenticated AuthStatus = iota
+	NotAuthenticated
+	CLIMissing
+)
+
+// GKEDiscoverer lists GKE clusters across the projects configured in the
+// user's named gcloud configurations (e.g. dev-*, stage-*, prod-*).
+type GKEDiscoverer struct {
+	exec executor.CommandExecutor
+}
+
+func NewGKEDiscoverer(exec executor.CommandExecutor) *GKEDiscoverer {
+	return &GKEDiscoverer{exec: exec}
+}
+
+// AuthStatus probes gcloud without failing: a missing binary and a logged-out
+// state are states to report, not errors.
+func (d *GKEDiscoverer) AuthStatus(ctx context.Context) AuthStatus {
+	result, err := d.exec.Execute(ctx, "gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)")
+	if err != nil {
+		if strings.Contains(err.Error(), "executable file not found") {
+			return CLIMissing
+		}
+		return NotAuthenticated
+	}
+	if result == nil || strings.TrimSpace(result.Stdout) == "" {
+		return NotAuthenticated
+	}
+	return Authenticated
+}
+
+// gcloudConfiguration is the subset of `gcloud config configurations list
+// --format=json` the discoverer reads.
+type gcloudConfiguration struct {
+	Name       string `json:"name"`
+	Properties struct {
+		Core struct {
+			Project string `json:"project"`
+		} `json:"core"`
+	} `json:"properties"`
+}
+
+// Projects returns the unique GCP projects named by the user's gcloud
+// configurations, sorted. Configurations without a project (or with the
+// literal "none") are skipped.
+func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
+	result, err := d.exec.Execute(ctx, "gcloud", "config", "configurations", "list", "--format=json")
+	if err != nil {
+		return nil, fmt.Errorf("listing gcloud configurations: %w", err)
+	}
+	var configs []gcloudConfiguration
+	if err := json.Unmarshal([]byte(result.Stdout), &configs); err != nil {
+		return nil, fmt.Errorf("parsing gcloud configurations: %w", err)
+	}
+	seen := map[string]bool{}
+	var projects []string
+	for _, c := range configs {
+		p := strings.TrimSpace(c.Properties.Core.Project)
+		if p == "" || p == "none" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		projects = append(projects, p)
+	}
+	sort.Strings(projects)
+	return projects, nil
+}
+
+// gkeCluster is the subset of `gcloud container clusters list --format=json`
+// the discoverer reads.
+type gkeCluster struct {
+	Name                 string `json:"name"`
+	Location             string `json:"location"`
+	Status               string `json:"status"`
+	CurrentNodeCount     int    `json:"currentNodeCount"`
+	CurrentMasterVersion string `json:"currentMasterVersion"`
+}
+
+// Result is one discovery pass: the clusters found plus per-project warnings
+// (permission denied on some projects must not hide the rest).
+type Result struct {
+	Clusters []models.ClusterInfo
+	Warnings []string
+}
+
+// Discover lists clusters in every configured project, best-effort per
+// project. Discovered entries carry Source=external and, when resolvable, the
+// kubeconfig context that reaches them.
+func (d *GKEDiscoverer) Discover(ctx context.Context) (Result, error) {
+	projects, err := d.Projects(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	contexts := kubeconfigContexts()
+
+	var res Result
+	for _, project := range projects {
+		result, err := d.exec.Execute(ctx, "gcloud", "container", "clusters", "list", "--project", project, "--format=json")
+		if err != nil {
+			// Typical: PERMISSION_DENIED on projects outside the user's role, or
+			// the container API disabled. Report and keep going.
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", project, err))
+			continue
+		}
+		var clusters []gkeCluster
+		if err := json.Unmarshal([]byte(result.Stdout), &clusters); err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: unparseable clusters list", project))
+			continue
+		}
+		for _, c := range clusters {
+			res.Clusters = append(res.Clusters, models.ClusterInfo{
+				Name:       c.Name,
+				Type:       models.ClusterTypeGKE,
+				Source:     models.SourceExternal,
+				Status:     titleCase(c.Status),
+				NodeCount:  c.CurrentNodeCount,
+				K8sVersion: c.CurrentMasterVersion,
+				Project:    project,
+				Region:     c.Location,
+				Context:    matchContext(contexts, project, c.Location, c.Name),
+			})
+		}
+	}
+	return res, nil
+}
+
+// kubeconfigContexts returns the context names of the user's kubeconfig
+// (honoring $KUBECONFIG); best-effort — a missing kubeconfig is fine.
+func kubeconfigContexts() []string {
+	cfg, err := clientcmd.NewDefaultPathOptions().GetStartingConfig()
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Contexts))
+	for name := range cfg.Contexts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// matchContext maps a discovered cluster onto a kubeconfig context by the
+// three conventional naming shapes; a renamed context cannot be matched and
+// yields "".
+func matchContext(contexts []string, project, location, name string) string {
+	candidates := []string{
+		name, // plain (openframe-style or hand-renamed to the cluster name)
+		fmt.Sprintf("gke_%s_%s_%s", project, location, name),            // gcloud get-credentials
+		fmt.Sprintf("connectgateway_%s_%s_%s", project, location, name), // fleet connect gateway
+	}
+	for _, want := range candidates {
+		for _, have := range contexts {
+			if have == want {
+				return have
+			}
+		}
+	}
+	return ""
+}
+
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	s = strings.ToLower(s)
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/cluster/discovery/gke_test.go
+++ b/internal/cluster/discovery/gke_test.go
@@ -1,0 +1,109 @@
+package discovery
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const configurationsJSON = `[
+  {"name": "default", "properties": {"core": {"project": "none"}}},
+  {"name": "dev-tenant-runners", "properties": {"core": {"project": "tenant-runners-db9z"}}},
+  {"name": "dev-shared", "properties": {"core": {"project": "shared-j62b"}}},
+  {"name": "dev-shared-dup", "properties": {"core": {"project": "shared-j62b"}}},
+  {"name": "prod-shared", "properties": {"core": {"project": "shared-4t5d"}}}
+]`
+
+const runnersClustersJSON = `[
+  {"name": "tenant-cluster-1", "location": "us-central1", "status": "RUNNING",
+   "currentNodeCount": 3, "currentMasterVersion": "1.33.2-gke.100"}
+]`
+
+func kubeconfigWith(t *testing.T, contexts map[string]string) {
+	t.Helper()
+	content := "apiVersion: v1\nkind: Config\nclusters:\ncontexts:\n"
+	for name := range contexts {
+		content += "- name: " + name + "\n  context:\n    cluster: c\n    user: u\n"
+	}
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	t.Setenv("KUBECONFIG", path)
+}
+
+func TestAuthStatus(t *testing.T) {
+	t.Run("active account", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "dev@flamingo.example\n"})
+		assert.Equal(t, Authenticated, NewGKEDiscoverer(mock).AuthStatus(context.Background()))
+	})
+
+	t.Run("no active account", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: ""})
+		assert.Equal(t, NotAuthenticated, NewGKEDiscoverer(mock).AuthStatus(context.Background()))
+	})
+
+	t.Run("gcloud errors map to not-authenticated", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetShouldFail(true, "not logged in")
+		assert.Equal(t, NotAuthenticated, NewGKEDiscoverer(mock).AuthStatus(context.Background()))
+	})
+}
+
+func TestProjects_DedupesAndSkipsEmpty(t *testing.T) {
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0, Stdout: configurationsJSON})
+
+	projects, err := NewGKEDiscoverer(mock).Projects(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared-4t5d", "shared-j62b", "tenant-runners-db9z"}, projects)
+}
+
+func TestDiscover_ListsClustersAcrossProjects(t *testing.T) {
+	kubeconfigWith(t, map[string]string{
+		"connectgateway_tenant-runners-db9z_us-central1_tenant-cluster-1": "",
+	})
+
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0, Stdout: configurationsJSON})
+	mock.SetResponse("clusters list --project tenant-runners-db9z", &executor.CommandResult{ExitCode: 0, Stdout: runnersClustersJSON})
+	mock.SetResponse("clusters list --project shared-j62b", &executor.CommandResult{ExitCode: 0, Stdout: "[]"})
+	// prod project: PERMISSION_DENIED must not break discovery of the rest.
+	mock.SetResponse("clusters list --project shared-4t5d", &executor.CommandResult{ExitCode: 1, Stderr: "PERMISSION_DENIED"})
+
+	result, err := NewGKEDiscoverer(mock).Discover(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, result.Clusters, 1)
+	c := result.Clusters[0]
+	assert.Equal(t, "tenant-cluster-1", c.Name)
+	assert.Equal(t, models.ClusterTypeGKE, c.Type)
+	assert.Equal(t, models.SourceExternal, c.Source)
+	assert.Equal(t, "Running", c.Status)
+	assert.Equal(t, 3, c.NodeCount)
+	assert.Equal(t, "tenant-runners-db9z", c.Project)
+	assert.Equal(t, "us-central1", c.Region)
+	assert.Equal(t, "connectgateway_tenant-runners-db9z_us-central1_tenant-cluster-1", c.Context)
+
+	require.Len(t, result.Warnings, 1)
+	assert.Contains(t, result.Warnings[0], "shared-4t5d")
+}
+
+func TestMatchContext(t *testing.T) {
+	contexts := []string{
+		"k3d-openframe-dev",
+		"gke_proj_us-central1_alpha",
+		"connectgateway_proj_us-central1_beta",
+		"gamma",
+	}
+	assert.Equal(t, "gke_proj_us-central1_alpha", matchContext(contexts, "proj", "us-central1", "alpha"))
+	assert.Equal(t, "connectgateway_proj_us-central1_beta", matchContext(contexts, "proj", "us-central1", "beta"))
+	assert.Equal(t, "gamma", matchContext(contexts, "proj", "us-central1", "gamma"))
+	assert.Equal(t, "", matchContext(contexts, "proj", "us-central1", "delta"))
+}

--- a/internal/cluster/models/cluster.go
+++ b/internal/cluster/models/cluster.go
@@ -38,10 +38,27 @@ type CloudConfig struct {
 	BackendConfig string `json:"backend_config,omitempty"`
 }
 
+// ClusterSource says who owns a cluster's lifecycle.
+type ClusterSource string
+
+const (
+	// SourceOpenframe: created by this CLI, has a workspace — full lifecycle.
+	SourceOpenframe ClusterSource = "openframe"
+	// SourceExternal: discovered in the cloud without a workspace — strictly
+	// read-only; every mutating command must refuse it.
+	SourceExternal ClusterSource = "external"
+)
+
 // ClusterInfo represents information about a cluster
 type ClusterInfo struct {
 	Name string      `json:"name"`
 	Type ClusterType `json:"type"`
+	// Source is empty for local (k3d) clusters, where ownership is implicit.
+	Source ClusterSource `json:"source,omitempty"`
+	// Context is the kubeconfig context that reaches this cluster, when known.
+	Context string `json:"context,omitempty"`
+	Project string `json:"project,omitempty"`
+	Region  string `json:"region,omitempty"`
 	// Status is a human-readable server fraction ("1/1"). Machine consumers
 	// should prefer ReadyServers/TotalServers (verification report: a string
 	// fraction forces JSON consumers to parse it).

--- a/internal/cluster/models/flags.go
+++ b/internal/cluster/models/flags.go
@@ -35,6 +35,8 @@ type CreateFlags struct {
 type ListFlags struct {
 	GlobalFlags
 	Quiet bool
+	// All additionally discovers external cloud clusters (read-only).
+	All bool
 }
 
 // StatusFlags contains flags specific to status command
@@ -84,6 +86,7 @@ func AddCreateFlags(cmd *cobra.Command, flags *CreateFlags) {
 // AddListFlags adds list-specific flags to a command
 func AddListFlags(cmd *cobra.Command, flags *ListFlags) {
 	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "q", false, "Only show cluster names")
+	cmd.Flags().BoolVarP(&flags.All, "all", "a", false, "Also discover external cloud clusters (read-only; needs provider CLI auth)")
 }
 
 // AddStatusFlags adds status-specific flags to a command
@@ -160,13 +163,16 @@ func ValidateCreateFlags(flags *CreateFlags) error {
 	}
 
 	// The wizard prompts for these; in skip-wizard mode they must come from
-	// flags.
+	// flags. EKS is exempt while its creation is gated behind the coming-soon
+	// banner — the banner must win over a missing-flag error.
 	isCloud := clusterType == ClusterTypeEKS || clusterType == ClusterTypeGKE
-	if isCloud && flags.SkipWizard && flags.Region == "" {
-		return fmt.Errorf("--region is required for --type %s with --skip-wizard", flags.ClusterType)
-	}
-	if clusterType == ClusterTypeGKE && flags.SkipWizard && flags.Project == "" {
-		return fmt.Errorf("--project is required for --type gke with --skip-wizard")
+	if clusterType == ClusterTypeGKE && flags.SkipWizard {
+		if flags.Region == "" {
+			return fmt.Errorf("--region is required for --type gke with --skip-wizard")
+		}
+		if flags.Project == "" {
+			return fmt.Errorf("--project is required for --type gke with --skip-wizard")
+		}
 	}
 	if flags.BackendConfig != "" && !isCloud {
 		return fmt.Errorf("--backend-config only applies to cloud cluster types (eks, gke)")

--- a/internal/cluster/providers/eks/kubeconfig.go
+++ b/internal/cluster/providers/eks/kubeconfig.go
@@ -77,11 +77,18 @@ func restConfigFor(rec tfengine.Record) (*rest.Config, error) {
 // mergeIntoDefaultKubeconfig writes the cluster's context into the user's
 // kubeconfig (honoring $KUBECONFIG) and switches the current context to it —
 // the same post-create behavior the k3d provider gets from k3d itself.
+// It refuses to overwrite a same-named context that points at a DIFFERENT
+// server (see the GKE twin for rationale).
 func mergeIntoDefaultKubeconfig(rec tfengine.Record) error {
 	pathOpts := clientcmd.NewDefaultPathOptions()
 	existing, err := pathOpts.GetStartingConfig()
 	if err != nil {
 		return fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	if prior, ok := existing.Contexts[rec.Name]; ok {
+		if cluster, ok := existing.Clusters[prior.Cluster]; ok && cluster.Server != rec.Endpoint {
+			return fmt.Errorf("kubeconfig context '%s' already exists and points at %s — refusing to overwrite it; rename the existing context or pick another cluster name", rec.Name, cluster.Server)
+		}
 	}
 	generated, err := kubeconfigFor(rec)
 	if err != nil {

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -304,6 +304,9 @@ func infoFor(rec tfengine.Record) models.ClusterInfo {
 	return models.ClusterInfo{
 		Name:       rec.Name,
 		Type:       models.ClusterTypeEKS,
+		Source:     models.SourceOpenframe,
+		Context:    rec.Name,
+		Region:     rec.Region,
 		Status:     strings.ToTitle(string(rec.Status[0:1])) + string(rec.Status[1:]),
 		NodeCount:  rec.NodeCount,
 		K8sVersion: rec.K8sVersion,

--- a/internal/cluster/providers/gke/kubeconfig.go
+++ b/internal/cluster/providers/gke/kubeconfig.go
@@ -66,11 +66,19 @@ func restConfigFor(rec tfengine.Record) (*rest.Config, error) {
 
 // mergeIntoDefaultKubeconfig writes the cluster's context into the user's
 // kubeconfig (honoring $KUBECONFIG) and switches the current context to it.
+// It refuses to overwrite a same-named context that points at a DIFFERENT
+// server: that context belongs to something else (another cluster, another
+// tool) and silently clobbering it would break the user's access to it.
 func mergeIntoDefaultKubeconfig(rec tfengine.Record) error {
 	pathOpts := clientcmd.NewDefaultPathOptions()
 	existing, err := pathOpts.GetStartingConfig()
 	if err != nil {
 		return fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	if prior, ok := existing.Contexts[rec.Name]; ok {
+		if cluster, ok := existing.Clusters[prior.Cluster]; ok && cluster.Server != rec.Endpoint {
+			return fmt.Errorf("kubeconfig context '%s' already exists and points at %s — refusing to overwrite it; rename the existing context or pick another cluster name", rec.Name, cluster.Server)
+		}
 	}
 	generated, err := kubeconfigFor(rec)
 	if err != nil {

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -58,6 +58,26 @@ func (p *Provider) preflightCredentials(ctx context.Context, project string) err
 	return nil
 }
 
+// preflightNameCollision refuses to create a cluster whose name already
+// exists in the target project but has no openframe workspace: terraform
+// would build the VPC first and then fail mid-apply on the duplicate cluster,
+// leaving partial billed infrastructure. External clusters are strictly not
+// ours to touch — the user must pick another name.
+//
+// Existence criterion: describe exits 0 AND prints exactly the cluster name
+// (--format=value(name) yields just that). Anything else — non-zero exit,
+// empty or unrelated output — is treated as "does not exist"; a genuinely
+// broken API call fails later with a clearer terraform error anyway.
+func (p *Provider) preflightNameCollision(ctx context.Context, config models.ClusterConfig) error {
+	result, err := p.executor.Execute(ctx, "gcloud", "container", "clusters", "describe", config.Name,
+		"--project", config.Cloud.Project, "--region", config.Cloud.Region, "--format=value(name)")
+	if err != nil || result == nil || strings.TrimSpace(result.Stdout) != config.Name {
+		return nil // not found (or indeterminate) — proceed
+	}
+	return fmt.Errorf("cluster '%s' already exists in project '%s' (region %s) but is not managed by openframe — refusing to touch it; pick another cluster name",
+		config.Name, config.Cloud.Project, config.Cloud.Region)
+}
+
 // backendTF renders the gcs backend block for a GKE workspace.
 func backendTF(cfg tfengine.BackendConfig) []byte {
 	return []byte(fmt.Sprintf(
@@ -130,7 +150,12 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	}
 
 	ws := p.registry.Workspace(config.Name)
+	// The collision check only guards NEW clusters: an existing workspace means
+	// the cloud cluster (partial or complete) is ours and create resumes it.
 	if !ws.Exists() {
+		if err := p.preflightNameCollision(ctx, config); err != nil {
+			return nil, err
+		}
 		vars, err := tfvarsFor(config)
 		if err != nil {
 			return nil, err
@@ -300,6 +325,10 @@ func infoFor(rec tfengine.Record) models.ClusterInfo {
 	return models.ClusterInfo{
 		Name:       rec.Name,
 		Type:       models.ClusterTypeGKE,
+		Source:     models.SourceOpenframe,
+		Context:    rec.Name,
+		Project:    rec.Project,
+		Region:     rec.Region,
 		Status:     strings.ToTitle(string(rec.Status[0:1])) + string(rec.Status[1:]),
 		NodeCount:  rec.NodeCount,
 		K8sVersion: rec.K8sVersion,

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -287,3 +287,67 @@ func TestCreateCluster_RejectsS3Backend(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be gcs://")
 	assert.Empty(t, *calls)
 }
+
+// TestCreateCluster_RefusesExternalNameCollision locks the ownership boundary:
+// a cluster that already exists in the project WITHOUT an openframe workspace
+// is somebody else's — create must refuse before any terraform runs (terraform
+// would build the VPC first and fail mid-apply, leaving billed debris).
+func TestCreateCluster_RefusesExternalNameCollision(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud container clusters describe demo", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	p.executor = mock
+
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not managed by openframe")
+	assert.Empty(t, *calls, "terraform must not run on a name collision")
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound, "no workspace must be scaffolded")
+}
+
+// TestCreateCluster_ResumeSkipsCollisionCheck: an existing workspace means the
+// cloud cluster is OURS (possibly partially created) — resume must proceed
+// even though describe would find it.
+func TestCreateCluster_ResumeSkipsCollisionCheck(t *testing.T) {
+	p, calls, _ := newTestProvider(t, nil)
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err)
+
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud container clusters describe demo", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	p.executor = mock
+
+	*calls = nil
+	_, err = p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err, "resume of an owned cluster must not be blocked by the collision check")
+	assert.Contains(t, *calls, "apply")
+}
+
+// TestCreateCluster_RefusesKubeconfigContextClobber: a same-named kubeconfig
+// context pointing at a DIFFERENT server belongs to something else and must
+// not be overwritten.
+func TestCreateCluster_RefusesKubeconfigContextClobber(t *testing.T) {
+	p, _, _ := newTestProvider(t, nil)
+	kubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- name: other
+  cluster:
+    server: https://somebody-elses.example:6443
+contexts:
+- name: demo
+  context:
+    cluster: other
+    user: other
+users:
+- name: other
+`
+	require.NoError(t, os.WriteFile(os.Getenv("KUBECONFIG"), []byte(kubeconfig), 0o600))
+
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to overwrite")
+}

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -919,12 +919,20 @@ func (s *ClusterService) DisplayClusterList(clusters []models.ClusterInfo, quiet
 		return nil
 	}
 
-	// Convert to UI display format
+	// Convert to UI display format. Local clusters have no explicit source —
+	// label them "local" so the SOURCE column is never ambiguous.
 	displayClusters := make([]uiCluster.ClusterDisplayInfo, len(clusters))
 	for i, cluster := range clusters {
+		source := string(cluster.Source)
+		if source == "" {
+			source = "local"
+		}
 		displayClusters[i] = uiCluster.ClusterDisplayInfo{
 			Name:      cluster.Name,
 			Type:      string(cluster.Type),
+			Source:    source,
+			Context:   cluster.Context,
+			Project:   cluster.Project,
 			Status:    cluster.Status,
 			NodeCount: cluster.NodeCount,
 			CreatedAt: cluster.CreatedAt,

--- a/internal/cluster/ui/service.go
+++ b/internal/cluster/ui/service.go
@@ -13,6 +13,9 @@ import (
 type ClusterDisplayInfo struct {
 	Name      string
 	Type      string
+	Source    string // "local" | "openframe" | "external"
+	Context   string // kubeconfig context, when known
+	Project   string // GCP project (cloud clusters)
 	Status    string
 	NodeCount int
 	CreatedAt time.Time
@@ -42,20 +45,54 @@ func (s *DisplayService) ShowClusterList(clusters []ClusterDisplayInfo, out io.W
 		return
 	}
 
-	// Create table data
-	tableData := pterm.TableData{
-		{"NAME", "TYPE", "STATUS", "NODES", "CREATED"},
+	// The SOURCE/CONTEXT/PROJECT columns only appear when the list contains
+	// cloud entries — a purely local listing keeps its compact shape.
+	hasCloud := false
+	for _, c := range clusters {
+		if c.Source != "" && c.Source != "local" {
+			hasCloud = true
+			break
+		}
 	}
 
+	header := []string{"NAME", "TYPE", "STATUS", "NODES", "CREATED"}
+	if hasCloud {
+		header = []string{"NAME", "TYPE", "SOURCE", "STATUS", "NODES", "CONTEXT", "PROJECT", "CREATED"}
+	}
+	tableData := pterm.TableData{header}
+
+	orDash := func(s string) string {
+		if s == "" {
+			return "—"
+		}
+		return s
+	}
 	for _, clusterInfo := range clusters {
 		statusColor := sharedUI.GetStatusColor(clusterInfo.Status)
-		tableData = append(tableData, []string{
+		created := ""
+		if !clusterInfo.CreatedAt.IsZero() {
+			created = clusterInfo.CreatedAt.Format("2006-01-02 15:04")
+		}
+		row := []string{
 			pterm.Bold.Sprint(clusterInfo.Name),
 			clusterInfo.Type,
 			statusColor(clusterInfo.Status),
 			fmt.Sprintf("%d", clusterInfo.NodeCount),
-			clusterInfo.CreatedAt.Format("2006-01-02 15:04"),
-		})
+			created,
+		}
+		if hasCloud {
+			row = []string{
+				pterm.Bold.Sprint(clusterInfo.Name),
+				clusterInfo.Type,
+				orDash(clusterInfo.Source),
+				statusColor(clusterInfo.Status),
+				fmt.Sprintf("%d", clusterInfo.NodeCount),
+				orDash(clusterInfo.Context),
+				orDash(clusterInfo.Project),
+				created,
+			}
+		}
+		tableData = append(tableData, row)
 	}
 
 	// Use pterm table for better formatting - but write to the provided writer

--- a/internal/cluster/ui/wizard_steps.go
+++ b/internal/cluster/ui/wizard_steps.go
@@ -41,14 +41,16 @@ func (ws *WizardSteps) PromptClusterName(defaultName string) (string, error) {
 	return strings.TrimSpace(result), nil
 }
 
-// PromptClusterType prompts for cluster type selection.
+// PromptClusterType prompts for cluster type selection. AWS EKS is listed but
+// gated: choosing it shows the coming-soon banner and re-prompts, so the
+// wizard never produces an EKS config while creation is stubbed.
 func (ws *WizardSteps) PromptClusterType() (models.ClusterType, error) {
 	prompt := promptui.Select{
 		Label: "Cluster Type",
 		Items: []string{
 			"k3d (Recommended for local development)",
-			"eks (AWS Elastic Kubernetes Service — provisions cloud resources that cost money)",
 			"gke (Google Kubernetes Engine — provisions cloud resources that cost money)",
+			"eks (AWS Elastic Kubernetes Service — coming soon)",
 		},
 		Templates: &promptui.SelectTemplates{
 			Label:    "{{ . }}:",
@@ -58,17 +60,20 @@ func (ws *WizardSteps) PromptClusterType() (models.ClusterType, error) {
 		},
 	}
 
-	idx, _, err := prompt.Run()
-	if err != nil {
-		return "", err
-	}
-	switch idx {
-	case 1:
-		return models.ClusterTypeEKS, nil
-	case 2:
-		return models.ClusterTypeGKE, nil
-	default:
-		return models.ClusterTypeK3d, nil
+	for {
+		idx, _, err := prompt.Run()
+		if err != nil {
+			return "", err
+		}
+		switch idx {
+		case 1:
+			return models.ClusterTypeGKE, nil
+		case 2:
+			pterm.Info.Println("AWS EKS support is coming soon — pick k3d or gke for now")
+			continue
+		default:
+			return models.ClusterTypeK3d, nil
+		}
 	}
 }
 

--- a/internal/cluster/utils/cmd_helpers.go
+++ b/internal/cluster/utils/cmd_helpers.go
@@ -43,6 +43,18 @@ func GetCommandService() *cluster.ClusterService {
 	return cluster.NewClusterService(exec)
 }
 
+// CommandExecutor returns the executor commands should shell through: the
+// injected test executor when present (hermetic cmd-layer tests), otherwise a
+// real one honoring the global --dry-run/--verbose flags.
+func CommandExecutor() executor.CommandExecutor {
+	if globalFlags != nil && globalFlags.Executor != nil {
+		return globalFlags.Executor
+	}
+	dryRun := globalFlags != nil && globalFlags.Global != nil && globalFlags.Global.DryRun
+	verbose := globalFlags != nil && globalFlags.Global != nil && globalFlags.Global.Verbose
+	return executor.NewRealCommandExecutor(dryRun, verbose)
+}
+
 // WrapCommandWithCommonSetup wraps a command function with common CLI setup and error handling
 func WrapCommandWithCommonSetup(runFunc func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
- ClusterSource (openframe|external): external clusters are strictly read-only; every mutating command refuses them
- create safety: GKE name-collision preflight refuses to touch an existing unmanaged cluster BEFORE terraform runs (resume of owned workspaces is unaffected); kubeconfig merge refuses to clobber same-named contexts that point elsewhere (gke + eks)
- discovery: GKE clusters across the projects of the user's gcloud configurations, best-effort per project, mapped to kubeconfig contexts (plain | gke_* | connectgateway_*)
- cluster list --all: managed + external with SOURCE/CONTEXT/PROJECT columns; logged-out gcloud degrades to an auth hint, never an error
- EKS creation gated behind a coming-soon banner (wizard re-prompts; status/delete/resume of existing EKS clusters keep working)