### PR TITLE
feat(cluster): openframe cluster use — switch kubectl context to any visible cluster

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -21,9 +21,10 @@ func GetClusterCmd() *cobra.Command {
 
 This command group provides cluster lifecycle management functionality:
   • create - Create a new cluster with interactive configuration
-  • delete - Remove a cluster and clean up resources  
+  • delete - Remove a cluster and clean up resources
   • list - Show all managed clusters
   • status - Display detailed cluster information
+  • use - Switch the kubectl context to a cluster
   • cleanup - Remove unused images and resources
 
 Supports K3d clusters for local development and AWS EKS for cloud deployments.
@@ -47,9 +48,10 @@ Examples:
 				ui.ShowLogoWithContext(cmd.Context())
 			}
 			// create runs its own type-aware gate after the cluster type is known
-			// (a cloud cluster must not demand Docker/k3d); the other subcommands
-			// are k3d-scoped, so the k3d gate stays here.
-			if cmd.Name() == "create" {
+			// (a cloud cluster must not demand Docker/k3d); use only flips local
+			// kubeconfig/gcloud state and needs no tools at all. The other
+			// subcommands are k3d-scoped, so the k3d gate stays here.
+			if cmd.Name() == "create" || cmd.Name() == "use" {
 				return nil
 			}
 			return prerequisites.CheckPrerequisites()
@@ -67,6 +69,7 @@ Examples:
 		getDeleteCmd(),
 		getListCmd(),
 		getStatusCmd(),
+		getUseCmd(),
 		getCleanupCmd(),
 	)
 

--- a/cmd/cluster/contract_test.go
+++ b/cmd/cluster/contract_test.go
@@ -18,7 +18,7 @@ func TestClusterContract_RootShape(t *testing.T) {
 	assert.Equal(t, "cluster", cluster.Name())
 	assert.ElementsMatch(t, []string{"k"}, cluster.Aliases, "k alias is part of the contract")
 
-	testutil.AssertSubcommands(t, cluster, "create", "list", "delete", "status", "cleanup")
+	testutil.AssertSubcommands(t, cluster, "create", "list", "delete", "status", "use", "cleanup")
 }
 
 func TestClusterContract_Flags(t *testing.T) {

--- a/cmd/cluster/use.go
+++ b/cmd/cluster/use.go
@@ -1,0 +1,164 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
+	"github.com/flamingo-stack/openframe-cli/internal/k8s"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func getUseCmd() *cobra.Command {
+	// Ensure global flags are initialized
+	utils.InitGlobalFlags()
+
+	useCmd := &cobra.Command{
+		Use:   "use [NAME]",
+		Short: "Switch the kubectl context to a cluster",
+		Long: `Switch the current kubectl context (and, for GKE, the active gcloud
+configuration) to the named cluster.
+
+Works for every cluster the CLI can see: local k3d clusters, clusters created
+by openframe, and external GKE clusters discovered in your gcloud projects.
+For an external cluster without a kubeconfig entry, credentials are fetched
+via 'gcloud container clusters get-credentials' first.
+
+Only local configuration changes: the cluster itself is never touched.
+
+Examples:
+  openframe cluster use openframe-dev     # local k3d
+  openframe cluster use my-gke            # openframe-managed GKE
+  openframe cluster use tenant-cluster-1  # external GKE (discovered)
+  openframe cluster use                   # interactive selection`,
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			utils.SyncGlobalFlags()
+			return utils.ValidateGlobalFlags()
+		},
+		RunE: utils.WrapCommandWithCommonSetup(runUseCluster),
+	}
+
+	return useCmd
+}
+
+func runUseCluster(cmd *cobra.Command, args []string) error {
+	service := utils.GetCommandService()
+	exec := utils.CommandExecutor()
+	ctx := cmd.Context()
+
+	// Resolve the cluster name: explicit arg, or interactive selection from
+	// the clusters the CLI already knows (local + managed — fast, no cloud
+	// calls; external clusters are addressed by explicit name).
+	name := ""
+	if len(args) > 0 {
+		name = strings.TrimSpace(args[0])
+	} else {
+		clusters, err := service.ListClusters()
+		if err != nil {
+			return fmt.Errorf("failed to list clusters: %w", err)
+		}
+		name, err = ui.SelectClusterByName(clusters, "Select a cluster to use")
+		if err != nil {
+			return err
+		}
+		if name == "" {
+			return nil
+		}
+	}
+
+	kubeconfig := k8s.DefaultKubeconfigPath()
+
+	// 1) Clusters the CLI knows: managed cloud (registry) or local k3d.
+	if clusterType, err := service.DetectClusterType(name); err == nil {
+		contextName := name
+		if clusterType == models.ClusterTypeK3d {
+			contextName = k8s.ResolveContextForCluster(kubeconfig, name)
+		}
+		if clusterType == models.ClusterTypeGKE {
+			if info, err := service.GetClusterStatus(name); err == nil {
+				alignGcloudConfiguration(ctx, exec, info.Project)
+			}
+		}
+		return switchTo(kubeconfig, contextName, name)
+	}
+
+	// 2) External GKE clusters, addressed by name via discovery.
+	return useExternalGKE(ctx, exec, kubeconfig, name)
+}
+
+// useExternalGKE finds an external cluster by name and points kubectl at it,
+// fetching credentials when the kubeconfig has no entry yet.
+func useExternalGKE(ctx context.Context, exec executor.CommandExecutor, kubeconfig, name string) error {
+	d := discovery.NewGKEDiscoverer(exec)
+	switch d.AuthStatus(ctx) {
+	case discovery.CLIMissing:
+		return fmt.Errorf("cluster '%s' is not known locally, and gcloud is not installed to look for it in GCP", name)
+	case discovery.NotAuthenticated:
+		return fmt.Errorf("cluster '%s' is not known locally; run 'gcloud auth login' to look for it in your GCP projects", name)
+	}
+
+	result, err := d.Discover(ctx)
+	if err != nil {
+		return err
+	}
+	var found *models.ClusterInfo
+	for i := range result.Clusters {
+		if result.Clusters[i].Name == name {
+			found = &result.Clusters[i]
+			break
+		}
+	}
+	if found == nil {
+		return fmt.Errorf("cluster '%s' not found locally or in the %s", name, "GCP projects of your gcloud configurations")
+	}
+
+	alignGcloudConfiguration(ctx, exec, found.Project)
+
+	contextName := found.Context
+	if contextName == "" {
+		// No kubeconfig entry yet — fetch credentials (adds the gke_* context).
+		pterm.Info.Printf("Fetching credentials for '%s' (project %s, %s)...\n", name, found.Project, found.Region)
+		if _, err := exec.Execute(ctx, "gcloud", "container", "clusters", "get-credentials", name,
+			"--project", found.Project, "--region", found.Region); err != nil {
+			return fmt.Errorf("could not fetch credentials for '%s' (for private clusters try 'gcloud container fleet memberships get-credentials %s'): %w", name, name, err)
+		}
+		contextName = fmt.Sprintf("gke_%s_%s_%s", found.Project, found.Region, name)
+	}
+	return switchTo(kubeconfig, contextName, name)
+}
+
+// switchTo flips current-context and reports the result.
+func switchTo(kubeconfig, contextName, clusterName string) error {
+	if !k8s.HasContext(kubeconfig, contextName) {
+		return fmt.Errorf("cluster '%s' has no kubeconfig context '%s' — fetch credentials for it first", clusterName, contextName)
+	}
+	if err := k8s.SwitchContext(kubeconfig, contextName); err != nil {
+		return err
+	}
+	pterm.Success.Printf("Switched kubectl context to '%s' (cluster '%s')\n", contextName, clusterName)
+	return nil
+}
+
+// alignGcloudConfiguration activates the gcloud configuration whose project
+// matches the cluster, so gcloud commands line up with kubectl. Best-effort:
+// no matching configuration is fine, and failures never block the switch.
+func alignGcloudConfiguration(ctx context.Context, exec executor.CommandExecutor, project string) {
+	if project == "" {
+		return
+	}
+	d := discovery.NewGKEDiscoverer(exec)
+	configName, err := d.ConfigurationForProject(ctx, project)
+	if err != nil || configName == "" {
+		return
+	}
+	if _, err := exec.Execute(ctx, "gcloud", "config", "configurations", "activate", configName); err == nil {
+		pterm.Info.Printf("Activated gcloud configuration '%s' (project %s)\n", configName, project)
+	}
+}

--- a/cmd/cluster/use_test.go
+++ b/cmd/cluster/use_test.go
@@ -1,0 +1,137 @@
+package cluster
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
+	"github.com/flamingo-stack/openframe-cli/internal/k8s"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+)
+
+// writeUseKubeconfig writes a kubeconfig with the given context names and
+// points $KUBECONFIG at it.
+func writeUseKubeconfig(t *testing.T, current string, contexts ...string) string {
+	t.Helper()
+	content := "apiVersion: v1\nkind: Config\ncurrent-context: " + current + "\nclusters:\n- name: c\n  cluster:\n    server: https://x.example\ncontexts:\n"
+	for _, name := range contexts {
+		content += "- name: " + name + "\n  context:\n    cluster: c\n    user: u\n"
+	}
+	content += "users:\n- name: u\n"
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", path)
+	return path
+}
+
+func setupUse(t *testing.T) *executor.MockCommandExecutor {
+	t.Helper()
+	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
+	utils.InitGlobalFlags()
+	mock := executor.NewMockCommandExecutor()
+	utils.SetTestExecutor(mock)
+	t.Cleanup(utils.ResetGlobalFlags)
+	return mock
+}
+
+func TestRunUseCluster_K3d(t *testing.T) {
+	mock := setupUse(t)
+	mock.SetResponse("k3d cluster get dev", &executor.CommandResult{ExitCode: 0, Stdout: "dev"})
+	path := writeUseKubeconfig(t, "other", "other", "k3d-dev")
+
+	if err := runUseCluster(getUseCmd(), []string{"dev"}); err != nil {
+		t.Fatalf("use k3d: %v", err)
+	}
+	_, current, _ := k8s.LoadContexts(path)
+	if current != "k3d-dev" {
+		t.Fatalf("current-context = %q, want k3d-dev", current)
+	}
+}
+
+func TestRunUseCluster_ManagedGKEAlignsGcloudConfiguration(t *testing.T) {
+	mock := setupUse(t)
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"dev-x","properties":{"core":{"project":"proj-x"}}}]`})
+	record := terraform.Record{
+		Name: "my-gke", Type: models.ClusterTypeGKE, Status: terraform.StatusReady,
+		Region: "us-central1", Project: "proj-x", NodeCount: 3,
+	}
+	reg := terraform.NewRegistry(os.Getenv("OPENFRAME_CLUSTERS_DIR"))
+	if err := reg.Workspace("my-gke").Scaffold(record, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	path := writeUseKubeconfig(t, "other", "other", "my-gke")
+
+	if err := runUseCluster(getUseCmd(), []string{"my-gke"}); err != nil {
+		t.Fatalf("use managed gke: %v", err)
+	}
+	_, current, _ := k8s.LoadContexts(path)
+	if current != "my-gke" {
+		t.Fatalf("current-context = %q, want my-gke", current)
+	}
+	if !mock.WasCommandExecuted("gcloud config configurations activate dev-x") {
+		t.Fatal("expected the matching gcloud configuration to be activated")
+	}
+}
+
+func TestRunUseCluster_ExternalGKEWithExistingContext(t *testing.T) {
+	mock := setupUse(t)
+	path := writeUseKubeconfig(t, "other", "other", "connectgateway_proj-x_us-central1_ext-1")
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"dev-x","properties":{"core":{"project":"proj-x"}}}]`})
+	mock.SetResponse("clusters list --project proj-x", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"ext-1","location":"us-central1","status":"RUNNING","currentNodeCount":2}]`})
+	// k3d detection must miss so the flow falls through to discovery.
+	mock.SetResponse("k3d cluster get ext-1", &executor.CommandResult{ExitCode: 1, Stderr: "not found"})
+
+	if err := runUseCluster(getUseCmd(), []string{"ext-1"}); err != nil {
+		t.Fatalf("use external gke: %v", err)
+	}
+	_, current, _ := k8s.LoadContexts(path)
+	if current != "connectgateway_proj-x_us-central1_ext-1" {
+		t.Fatalf("current-context = %q", current)
+	}
+	if mock.WasCommandExecuted("get-credentials") {
+		t.Fatal("credentials must not be re-fetched when a context already exists")
+	}
+}
+
+func TestRunUseCluster_ExternalGKEFetchesCredentials(t *testing.T) {
+	mock := setupUse(t)
+	writeUseKubeconfig(t, "other", "other")
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"dev-x","properties":{"core":{"project":"proj-x"}}}]`})
+	mock.SetResponse("clusters list --project proj-x", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"ext-1","location":"us-central1","status":"RUNNING","currentNodeCount":2}]`})
+	mock.SetResponse("k3d cluster get ext-1", &executor.CommandResult{ExitCode: 1, Stderr: "not found"})
+
+	err := runUseCluster(getUseCmd(), []string{"ext-1"})
+	// The mock cannot actually write the gke_* context, so the switch fails —
+	// but the credentials fetch must have been attempted first.
+	if !mock.WasCommandExecuted("gcloud container clusters get-credentials ext-1") {
+		t.Fatal("expected a get-credentials attempt for a context-less external cluster")
+	}
+	if err == nil || !strings.Contains(err.Error(), "no kubeconfig context") {
+		t.Fatalf("expected a missing-context error after mock fetch, got: %v", err)
+	}
+}
+
+func TestRunUseCluster_NotAuthenticatedIsActionable(t *testing.T) {
+	mock := setupUse(t)
+	writeUseKubeconfig(t, "other", "other")
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: ""})
+	mock.SetResponse("k3d cluster get ghost", &executor.CommandResult{ExitCode: 1, Stderr: "not found"})
+
+	err := runUseCluster(getUseCmd(), []string{"ghost"})
+	if err == nil || !strings.Contains(err.Error(), "gcloud auth login") {
+		t.Fatalf("expected an auth hint, got: %v", err)
+	}
+}

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -78,10 +78,16 @@ create, only after a successful delete.
 
 ```bash
 openframe cluster list                # local + cloud clusters
+openframe cluster list --all          # + external clusters discovered in your GCP projects
+openframe cluster use my-gke          # switch kubectl context (and gcloud configuration)
 openframe cluster status my-eks
 openframe cluster delete my-eks       # terraform destroy; asks to re-type the name
 openframe app install                 # install OpenFrame onto the current context
 ```
+
+`cluster use` works for external (discovered) GKE clusters too: it fetches
+credentials via gcloud when the kubeconfig has no entry yet, and activates
+the gcloud configuration matching the cluster's project.
 
 `cluster delete --force` skips the typed confirmation (for CI). `cluster
 cleanup` does not apply to cloud clusters — use `delete`.

--- a/internal/cluster/discovery/gke.go
+++ b/internal/cluster/discovery/gke.go
@@ -68,10 +68,8 @@ type gcloudConfiguration struct {
 	} `json:"properties"`
 }
 
-// Projects returns the unique GCP projects named by the user's gcloud
-// configurations, sorted. Configurations without a project (or with the
-// literal "none") are skipped.
-func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
+// configurations lists and parses the user's named gcloud configurations.
+func (d *GKEDiscoverer) configurations(ctx context.Context) ([]gcloudConfiguration, error) {
 	result, err := d.exec.Execute(ctx, "gcloud", "config", "configurations", "list", "--format=json")
 	if err != nil {
 		return nil, fmt.Errorf("listing gcloud configurations: %w", err)
@@ -79,6 +77,17 @@ func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
 	var configs []gcloudConfiguration
 	if err := json.Unmarshal([]byte(result.Stdout), &configs); err != nil {
 		return nil, fmt.Errorf("parsing gcloud configurations: %w", err)
+	}
+	return configs, nil
+}
+
+// Projects returns the unique GCP projects named by the user's gcloud
+// configurations, sorted. Configurations without a project (or with the
+// literal "none") are skipped.
+func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
+	configs, err := d.configurations(ctx)
+	if err != nil {
+		return nil, err
 	}
 	seen := map[string]bool{}
 	var projects []string
@@ -92,6 +101,21 @@ func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
 	}
 	sort.Strings(projects)
 	return projects, nil
+}
+
+// ConfigurationForProject returns the name of the first gcloud configuration
+// pointing at the given project, or "" when none does.
+func (d *GKEDiscoverer) ConfigurationForProject(ctx context.Context, project string) (string, error) {
+	configs, err := d.configurations(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, c := range configs {
+		if strings.TrimSpace(c.Properties.Core.Project) == project {
+			return c.Name, nil
+		}
+	}
+	return "", nil
 }
 
 // gkeCluster is the subset of `gcloud container clusters list --format=json`

--- a/internal/cluster/discovery/gke_test.go
+++ b/internal/cluster/discovery/gke_test.go
@@ -107,3 +107,17 @@ func TestMatchContext(t *testing.T) {
 	assert.Equal(t, "gamma", matchContext(contexts, "proj", "us-central1", "gamma"))
 	assert.Equal(t, "", matchContext(contexts, "proj", "us-central1", "delta"))
 }
+
+func TestConfigurationForProject(t *testing.T) {
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0, Stdout: configurationsJSON})
+	d := NewGKEDiscoverer(mock)
+
+	name, err := d.ConfigurationForProject(context.Background(), "tenant-runners-db9z")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-tenant-runners", name)
+
+	name, err = d.ConfigurationForProject(context.Background(), "unknown-project")
+	require.NoError(t, err)
+	assert.Equal(t, "", name)
+}

--- a/internal/k8s/contexts.go
+++ b/internal/k8s/contexts.go
@@ -7,6 +7,7 @@
 package k8s
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -55,6 +56,39 @@ func ResolveContextForCluster(kubeconfigPath, clusterName string) string {
 		}
 	}
 	return k3d
+}
+
+// HasContext reports whether the kubeconfig at path contains a context with
+// the given name. An unreadable kubeconfig counts as "no".
+func HasContext(path, name string) bool {
+	contexts, _, err := LoadContexts(path)
+	if err != nil {
+		return false
+	}
+	for _, c := range contexts {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// SwitchContext sets current-context in the kubeconfig at path. It only
+// changes the pointer — never contexts, clusters, or users — so it cannot
+// damage entries owned by other tools.
+func SwitchContext(path, name string) error {
+	cfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	if _, ok := cfg.Contexts[name]; !ok {
+		return fmt.Errorf("kubeconfig has no context '%s'", name)
+	}
+	cfg.CurrentContext = name
+	if err := clientcmd.WriteToFile(*cfg, path); err != nil {
+		return fmt.Errorf("writing kubeconfig: %w", err)
+	}
+	return nil
 }
 
 // LoadContexts reads the kubeconfig at path and returns its contexts (sorted by

--- a/internal/k8s/contexts_test.go
+++ b/internal/k8s/contexts_test.go
@@ -96,3 +96,51 @@ func TestDefaultKubeconfigPath_EnvWins(t *testing.T) {
 	t.Setenv("KUBECONFIG", "/custom/kubeconfig")
 	assert.Equal(t, "/custom/kubeconfig", DefaultKubeconfigPath())
 }
+
+func TestSwitchContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	kubeconfig := `apiVersion: v1
+kind: Config
+current-context: alpha
+clusters:
+- name: c1
+  cluster:
+    server: https://a.example
+contexts:
+- name: alpha
+  context:
+    cluster: c1
+    user: u
+- name: beta
+  context:
+    cluster: c1
+    user: u
+users:
+- name: u
+`
+	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasContext(path, "beta") || HasContext(path, "ghost") {
+		t.Fatal("HasContext misreports")
+	}
+
+	if err := SwitchContext(path, "beta"); err != nil {
+		t.Fatalf("SwitchContext: %v", err)
+	}
+	_, current, err := LoadContexts(path)
+	if err != nil || current != "beta" {
+		t.Fatalf("current-context = %q (err %v), want beta", current, err)
+	}
+
+	// Switching only flips the pointer — both contexts must survive.
+	contexts, _, _ := LoadContexts(path)
+	if len(contexts) != 2 {
+		t.Fatalf("contexts damaged: %v", contexts)
+	}
+
+	if err := SwitchContext(path, "ghost"); err == nil {
+		t.Fatal("switching to a missing context must fail")
+	}
+}


### PR DESCRIPTION
- resolves local k3d (k3d-<name>/exact context), openframe-managed cloud (context = cluster name), and external GKE clusters found via discovery
- external clusters without a kubeconfig entry get credentials fetched via `gcloud container clusters get-credentials` (private-cluster hint on failure); for GKE the gcloud configuration matching the cluster's project is activated so gcloud and kubectl line up
- k8s.SwitchContext flips only current-context — never rewrites contexts, clusters, or users; the cluster itself is never touched
- no-arg form offers interactive selection; logged-out gcloud yields an actionable auth hint; the prerequisite gate is skipped (no tools needed)