### PR TITLE
feat(cluster): single gcloud login flow across all GKE commands

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/provider"
@@ -92,6 +93,12 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 	planner, ok := p.(provider.Planner)
 	if !ok {
 		return nil
+	}
+
+	if config.Type == models.ClusterTypeGKE {
+		if err := discovery.NewAuthFlow(exec).Ensure(ctx, true); err != nil {
+			return err
+		}
 	}
 
 	pterm.Info.Printf("Computing terraform plan for %s cluster '%s'...\n", config.Type, config.Name)
@@ -225,6 +232,15 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 	// dry-run must not mutate the system.
 	if err := prerequisites.CheckForClusterType(config.Type); err != nil {
 		return err
+	}
+
+	// Single auth flow: for GKE, offer `gcloud auth login` (+ ADC for
+	// terraform) right here instead of failing later in the provider
+	// preflight with a "run this command" error.
+	if config.Type == models.ClusterTypeGKE {
+		if err := discovery.NewAuthFlow(utils.CommandExecutor()).Ensure(cmd.Context(), true); err != nil {
+			return err
+		}
 	}
 
 	// Execute cluster creation through service layer

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -100,12 +100,17 @@ func runListClusters(cmd *cobra.Command, args []string) error {
 func discoverExternalClusters(ctx context.Context, managed []models.ClusterInfo) ([]models.ClusterInfo, []string) {
 	notices := []string{"AWS EKS discovery is coming soon — external EKS clusters are not shown yet"}
 
-	d := discovery.NewGKEDiscoverer(utils.CommandExecutor())
+	exec := utils.CommandExecutor()
+	d := discovery.NewGKEDiscoverer(exec)
 	switch d.AuthStatus(ctx) {
 	case discovery.CLIMissing:
 		return nil, append(notices, "GKE: gcloud is not installed — install it to discover external clusters")
 	case discovery.NotAuthenticated:
-		return nil, append(notices, "GKE: not authenticated — run 'gcloud auth login' to discover external clusters")
+		// One unambiguous flow: offer the login right here (interactive only —
+		// non-interactive sessions get the same message as before).
+		if err := discovery.NewAuthFlow(exec).Ensure(ctx, false); err != nil {
+			return nil, append(notices, "GKE: "+err.Error())
+		}
 	}
 
 	result, err := d.Discover(ctx)

--- a/cmd/cluster/use.go
+++ b/cmd/cluster/use.go
@@ -101,7 +101,11 @@ func useExternalGKE(ctx context.Context, exec executor.CommandExecutor, kubeconf
 	case discovery.CLIMissing:
 		return fmt.Errorf("cluster '%s' is not known locally, and gcloud is not installed to look for it in GCP", name)
 	case discovery.NotAuthenticated:
-		return fmt.Errorf("cluster '%s' is not known locally; run 'gcloud auth login' to look for it in your GCP projects", name)
+		// One unambiguous flow: offer the login right here (interactive only).
+		pterm.Info.Printf("Cluster '%s' is not known locally — looking for it in your GCP projects requires a Google Cloud login\n", name)
+		if err := discovery.NewAuthFlow(exec).Ensure(ctx, false); err != nil {
+			return err
+		}
 	}
 
 	result, err := d.Discover(ctx)

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -19,7 +19,14 @@ Checked and installed automatically on `cluster create`:
 | eks  | terraform (pinned, verified), AWS CLI | working AWS credentials (`aws configure` or `--profile`) |
 | gke  | terraform (pinned, verified), gcloud, gke-gcloud-auth-plugin | `gcloud auth login` + a GCP project |
 
-Credentials are preflighted before anything is created (`aws sts
+**You do not need to log in beforehand.** When a command needs Google Cloud
+access (`create --type gke`, `list --all`, `use`), the CLI checks your gcloud
+auth state and, in an interactive session, offers to run `gcloud auth login`
+(and `gcloud auth application-default login` for Terraform) right there — one
+flow, no manual steps. Non-interactive sessions (CI) never prompt and fail
+with the exact command to run instead.
+
+Credentials are additionally preflighted before anything is created (`aws sts
 get-caller-identity` / `gcloud auth print-access-token`), so a broken login
 fails in seconds, not mid-provisioning.
 

--- a/internal/cluster/discovery/auth.go
+++ b/internal/cluster/discovery/auth.go
@@ -1,0 +1,113 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"strings"
+
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/pterm/pterm"
+)
+
+// AuthFlow is the single gcloud login flow every GKE-touching command goes
+// through: it checks the auth state and, in an interactive session, offers to
+// run `gcloud auth login` (and `gcloud auth application-default login` when
+// terraform needs ADC) right there — so the user never has to leave the CLI.
+// Non-interactive sessions never prompt (CI rule) and get an actionable error
+// instead.
+type AuthFlow struct {
+	exec executor.CommandExecutor
+	// interactive reports whether prompting is allowed; seam for tests.
+	interactive func() bool
+	// confirm asks the user; seam for tests.
+	confirm func(message string) (bool, error)
+	// runLogin runs a gcloud login command attached to the terminal (browser
+	// flows print URLs and read stdin, so it must bypass the capturing
+	// executor); seam for tests.
+	runLogin func(ctx context.Context, args ...string) error
+}
+
+// NewAuthFlow builds the production flow on the given executor (used for the
+// non-interactive status probes, so they stay mockable).
+func NewAuthFlow(exec executor.CommandExecutor) *AuthFlow {
+	return &AuthFlow{
+		exec:        exec,
+		interactive: func() bool { return !sharedUI.IsNonInteractive() },
+		confirm: func(message string) (bool, error) {
+			return sharedUI.ConfirmActionInteractive(message, true)
+		},
+		runLogin: func(ctx context.Context, args ...string) error {
+			cmd := osexec.CommandContext(ctx, "gcloud", args...) // #nosec G204 -- fixed argv assembled by this package, no user input
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			return cmd.Run()
+		},
+	}
+}
+
+// NewAuthFlowWithSeams is the test constructor.
+func NewAuthFlowWithSeams(exec executor.CommandExecutor, interactive func() bool,
+	confirm func(string) (bool, error), runLogin func(context.Context, ...string) error) *AuthFlow {
+	return &AuthFlow{exec: exec, interactive: interactive, confirm: confirm, runLogin: runLogin}
+}
+
+// Ensure makes sure gcloud is authenticated; with requireADC it also ensures
+// Application Default Credentials, which terraform's google provider uses —
+// `cluster create --type gke` needs both, discovery/use only the first.
+func (f *AuthFlow) Ensure(ctx context.Context, requireADC bool) error {
+	d := &GKEDiscoverer{exec: f.exec}
+	switch d.AuthStatus(ctx) {
+	case CLIMissing:
+		return fmt.Errorf("gcloud is not installed — install the Google Cloud SDK first (https://cloud.google.com/sdk/docs/install)")
+	case NotAuthenticated:
+		if err := f.login(ctx, "Google Cloud login required. Log in now (opens a browser)?",
+			[]string{"auth", "login"},
+			func() bool { return d.AuthStatus(ctx) == Authenticated },
+			"gcloud is not authenticated — run 'gcloud auth login'"); err != nil {
+			return err
+		}
+	}
+
+	if !requireADC {
+		return nil
+	}
+	if f.hasADC(ctx) {
+		return nil
+	}
+	return f.login(ctx, "Terraform needs Application Default Credentials. Set them up now (opens a browser)?",
+		[]string{"auth", "application-default", "login"},
+		func() bool { return f.hasADC(ctx) },
+		"Application Default Credentials are missing — run 'gcloud auth application-default login'")
+}
+
+// hasADC probes Application Default Credentials without prompting.
+func (f *AuthFlow) hasADC(ctx context.Context) bool {
+	result, err := f.exec.Execute(ctx, "gcloud", "auth", "application-default", "print-access-token")
+	return err == nil && result != nil && strings.TrimSpace(result.Stdout) != ""
+}
+
+// login runs one interactive login step: prompt → run → re-verify.
+func (f *AuthFlow) login(ctx context.Context, prompt string, args []string, verified func() bool, manualHint string) error {
+	if !f.interactive() {
+		return fmt.Errorf("%s", manualHint)
+	}
+	confirmed, err := f.confirm(prompt)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return fmt.Errorf("%s", manualHint)
+	}
+	if err := f.runLogin(ctx, args...); err != nil {
+		return fmt.Errorf("gcloud %s failed: %w", strings.Join(args, " "), err)
+	}
+	if !verified() {
+		return fmt.Errorf("login did not complete — %s", manualHint)
+	}
+	pterm.Success.Println("Google Cloud authentication complete")
+	return nil
+}

--- a/internal/cluster/discovery/auth_test.go
+++ b/internal/cluster/discovery/auth_test.go
@@ -1,0 +1,137 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// authFlowHarness wires an AuthFlow with recording seams.
+type authFlowHarness struct {
+	flow       *AuthFlow
+	mock       *executor.MockCommandExecutor
+	logins     []string
+	confirms   []string
+	confirmAns bool
+}
+
+func newAuthHarness(t *testing.T, interactive bool) *authFlowHarness {
+	t.Helper()
+	h := &authFlowHarness{mock: executor.NewMockCommandExecutor(), confirmAns: true}
+	h.flow = NewAuthFlowWithSeams(h.mock,
+		func() bool { return interactive },
+		func(msg string) (bool, error) {
+			h.confirms = append(h.confirms, msg)
+			return h.confirmAns, nil
+		},
+		func(ctx context.Context, args ...string) error {
+			joined := strings.Join(args, " ")
+			h.logins = append(h.logins, joined)
+			// A successful login makes ITS OWN subsequent status probe pass —
+			// `auth login` must not grant ADC and vice versa.
+			if strings.Contains(joined, "application-default") {
+				h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
+			} else {
+				h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+			}
+			return nil
+		})
+	return h
+}
+
+func (h *authFlowHarness) loggedOut() {
+	h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: ""})
+	h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "no credentials"})
+}
+
+func (h *authFlowHarness) loggedIn(withADC bool) {
+	h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	if withADC {
+		h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
+	} else {
+		h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "no credentials"})
+	}
+}
+
+func TestAuthFlow_AlreadyAuthenticatedIsSilent(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedIn(true)
+
+	require.NoError(t, h.flow.Ensure(context.Background(), true))
+	assert.Empty(t, h.logins, "no login must run when already authenticated")
+	assert.Empty(t, h.confirms, "no prompt must be shown when already authenticated")
+}
+
+func TestAuthFlow_InteractiveLoginRuns(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedOut()
+
+	require.NoError(t, h.flow.Ensure(context.Background(), false))
+	assert.Equal(t, []string{"auth login"}, h.logins)
+}
+
+func TestAuthFlow_ADCRequiredRunsBothLogins(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedOut()
+
+	require.NoError(t, h.flow.Ensure(context.Background(), true))
+	assert.Equal(t, []string{"auth login", "auth application-default login"}, h.logins)
+}
+
+func TestAuthFlow_ADCOnlyWhenCLICredsPresent(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedIn(false)
+
+	require.NoError(t, h.flow.Ensure(context.Background(), true))
+	assert.Equal(t, []string{"auth application-default login"}, h.logins)
+}
+
+func TestAuthFlow_NonInteractiveNeverPrompts(t *testing.T) {
+	h := newAuthHarness(t, false)
+	h.loggedOut()
+
+	err := h.flow.Ensure(context.Background(), true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcloud auth login")
+	assert.Empty(t, h.logins, "non-interactive sessions must never launch a login")
+	assert.Empty(t, h.confirms)
+}
+
+func TestAuthFlow_DeclinedGivesManualHint(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedOut()
+	h.confirmAns = false
+
+	err := h.flow.Ensure(context.Background(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gcloud auth login")
+	assert.Empty(t, h.logins)
+}
+
+func TestAuthFlow_FailedLoginSurfaces(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedOut()
+	h.flow.runLogin = func(ctx context.Context, args ...string) error {
+		return errors.New("browser exploded")
+	}
+
+	err := h.flow.Ensure(context.Background(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browser exploded")
+}
+
+func TestAuthFlow_UnverifiedLoginFails(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.loggedOut()
+	// Login "succeeds" but the status probe still reports logged-out.
+	h.flow.runLogin = func(ctx context.Context, args ...string) error { return nil }
+
+	err := h.flow.Ensure(context.Background(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not complete")
+}


### PR DESCRIPTION
- discovery.AuthFlow: check auth state → confirm → run `gcloud auth login` attached to the terminal → re-verify; `create --type gke` additionally ensures Application Default Credentials (terraform's google provider uses ADC, not CLI credentials)
- integrated into create (after the tool gate and in the dry-run preview), list --all (offers login instead of a hint), and use (before discovery)
- non-interactive sessions never prompt (CI rule) and get the exact command to run; declined or failed logins surface actionable errors
- all branches covered hermetically via interactive/confirm/runLogin seams