### PR TITLE
fix(cluster): make interrupted cloud creates resumable; tighten safety guards

### DIFF
--- a/internal/cluster/providers/eks/kubeconfig.go
+++ b/internal/cluster/providers/eks/kubeconfig.go
@@ -104,18 +104,24 @@ func mergeIntoDefaultKubeconfig(rec tfengine.Record) error {
 	return nil
 }
 
-// removeFromDefaultKubeconfig drops the cluster's context after a destroy.
+// removeFromDefaultKubeconfig drops the cluster's context after a destroy —
+// but ONLY when the entry still points at OUR endpoint (see the GKE twin).
 // Best-effort: a missing entry is not an error.
-func removeFromDefaultKubeconfig(name string) error {
+func removeFromDefaultKubeconfig(rec tfengine.Record) error {
 	pathOpts := clientcmd.NewDefaultPathOptions()
 	existing, err := pathOpts.GetStartingConfig()
 	if err != nil {
 		return err
 	}
-	delete(existing.Clusters, name)
-	delete(existing.AuthInfos, name)
-	delete(existing.Contexts, name)
-	if existing.CurrentContext == name {
+	if prior, ok := existing.Contexts[rec.Name]; ok {
+		if cluster, ok := existing.Clusters[prior.Cluster]; ok && cluster.Server != rec.Endpoint {
+			return nil // same name, different server — not ours anymore
+		}
+	}
+	delete(existing.Clusters, rec.Name)
+	delete(existing.AuthInfos, rec.Name)
+	delete(existing.Contexts, rec.Name)
+	if existing.CurrentContext == rec.Name {
 		existing.CurrentContext = ""
 	}
 	return clientcmd.ModifyConfig(pathOpts, *existing, true)

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -213,11 +213,16 @@ func (p *Provider) DeleteCluster(ctx context.Context, name string, clusterType m
 	if !ws.Exists() {
 		return models.NewClusterNotFoundError(name)
 	}
+	// Read the record BEFORE destroy: the endpoint in it is what proves the
+	// kubeconfig entry is ours to remove afterwards.
+	rec, recErr := ws.ReadRecord()
 	if err := p.engine.Destroy(ctx, ws.TerraformDir()); err != nil {
 		return models.NewClusterOperationError("delete", name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run delete to retry", err, ws.Dir()))
 	}
-	_ = removeFromDefaultKubeconfig(name)
+	if recErr == nil {
+		_ = removeFromDefaultKubeconfig(rec)
+	}
 	return ws.Remove()
 }
 

--- a/internal/cluster/providers/gke/kubeconfig.go
+++ b/internal/cluster/providers/gke/kubeconfig.go
@@ -94,17 +94,25 @@ func mergeIntoDefaultKubeconfig(rec tfengine.Record) error {
 	return nil
 }
 
-// removeFromDefaultKubeconfig drops the cluster's context after a destroy.
-func removeFromDefaultKubeconfig(name string) error {
+// removeFromDefaultKubeconfig drops the cluster's context after a destroy —
+// but ONLY when the entry still points at OUR endpoint. If the user repointed
+// or recreated a same-named context toward another server since the create,
+// it is no longer ours to delete (the create-side no-clobber guard's mirror).
+func removeFromDefaultKubeconfig(rec tfengine.Record) error {
 	pathOpts := clientcmd.NewDefaultPathOptions()
 	existing, err := pathOpts.GetStartingConfig()
 	if err != nil {
 		return err
 	}
-	delete(existing.Clusters, name)
-	delete(existing.AuthInfos, name)
-	delete(existing.Contexts, name)
-	if existing.CurrentContext == name {
+	if prior, ok := existing.Contexts[rec.Name]; ok {
+		if cluster, ok := existing.Clusters[prior.Cluster]; ok && cluster.Server != rec.Endpoint {
+			return nil // same name, different server — not ours anymore
+		}
+	}
+	delete(existing.Clusters, rec.Name)
+	delete(existing.AuthInfos, rec.Name)
+	delete(existing.Contexts, rec.Name)
+	if existing.CurrentContext == rec.Name {
 		existing.CurrentContext = ""
 	}
 	return clientcmd.ModifyConfig(pathOpts, *existing, true)

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -64,18 +64,24 @@ func (p *Provider) preflightCredentials(ctx context.Context, project string) err
 // leaving partial billed infrastructure. External clusters are strictly not
 // ours to touch — the user must pick another name.
 //
-// Existence criterion: describe exits 0 AND prints exactly the cluster name
-// (--format=value(name) yields just that). Anything else — non-zero exit,
-// empty or unrelated output — is treated as "does not exist"; a genuinely
-// broken API call fails later with a clearer terraform error anyway.
+// Existence criterion: the project-wide listing (deliberately NOT scoped to a
+// location — a ZONAL cluster with the same name must also count) prints a
+// line equal to the cluster name. Anything else — non-zero exit, empty or
+// unrelated output — is treated as "does not exist"; a genuinely broken API
+// call fails later with a clearer terraform error anyway.
 func (p *Provider) preflightNameCollision(ctx context.Context, config models.ClusterConfig) error {
-	result, err := p.executor.Execute(ctx, "gcloud", "container", "clusters", "describe", config.Name,
-		"--project", config.Cloud.Project, "--region", config.Cloud.Region, "--format=value(name)")
-	if err != nil || result == nil || strings.TrimSpace(result.Stdout) != config.Name {
-		return nil // not found (or indeterminate) — proceed
+	result, err := p.executor.Execute(ctx, "gcloud", "container", "clusters", "list",
+		"--project", config.Cloud.Project, "--filter=name="+config.Name, "--format=value(name)")
+	if err != nil || result == nil {
+		return nil // indeterminate — proceed
 	}
-	return fmt.Errorf("cluster '%s' already exists in project '%s' (region %s) but is not managed by openframe — refusing to touch it; pick another cluster name",
-		config.Name, config.Cloud.Project, config.Cloud.Region)
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if strings.TrimSpace(line) == config.Name {
+			return fmt.Errorf("cluster '%s' already exists in project '%s' but is not managed by openframe — refusing to touch it; pick another cluster name",
+				config.Name, config.Cloud.Project)
+		}
+	}
+	return nil
 }
 
 // backendTF renders the gcs backend block for a GKE workspace.
@@ -235,11 +241,16 @@ func (p *Provider) DeleteCluster(ctx context.Context, name string, clusterType m
 	if !ws.Exists() {
 		return models.NewClusterNotFoundError(name)
 	}
+	// Read the record BEFORE destroy: the endpoint in it is what proves the
+	// kubeconfig entry is ours to remove afterwards.
+	rec, recErr := ws.ReadRecord()
 	if err := p.engine.Destroy(ctx, ws.TerraformDir()); err != nil {
 		return models.NewClusterOperationError("delete", name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run delete to retry", err, ws.Dir()))
 	}
-	_ = removeFromDefaultKubeconfig(name)
+	if recErr == nil {
+		_ = removeFromDefaultKubeconfig(rec)
+	}
 	return ws.Remove()
 }
 

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -295,7 +295,7 @@ func TestCreateCluster_RejectsS3Backend(t *testing.T) {
 func TestCreateCluster_RefusesExternalNameCollision(t *testing.T) {
 	p, calls, registry := newTestProvider(t, nil)
 	mock := executor.NewMockCommandExecutor()
-	mock.SetResponse("gcloud container clusters describe demo", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	mock.SetResponse("clusters list --project my-project", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
 	p.executor = mock
 
 	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
@@ -317,7 +317,7 @@ func TestCreateCluster_ResumeSkipsCollisionCheck(t *testing.T) {
 	require.NoError(t, err)
 
 	mock := executor.NewMockCommandExecutor()
-	mock.SetResponse("gcloud container clusters describe demo", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	mock.SetResponse("clusters list --project my-project", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
 	p.executor = mock
 
 	*calls = nil
@@ -350,4 +350,54 @@ users:
 	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "refusing to overwrite")
+}
+
+// TestDeleteCluster_LeavesRepointedContextAlone (П4): if the user repointed a
+// same-named kubeconfig context at another server after the create, delete
+// must not remove it — the mirror of the create-side no-clobber guard.
+func TestDeleteCluster_LeavesRepointedContextAlone(t *testing.T) {
+	p, _, _ := newTestProvider(t, nil)
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err)
+
+	// Repoint the "demo" context at somebody else's server.
+	repointed := `apiVersion: v1
+kind: Config
+current-context: demo
+clusters:
+- name: demo
+  cluster:
+    server: https://somebody-elses.example:6443
+contexts:
+- name: demo
+  context:
+    cluster: demo
+    user: demo
+users:
+- name: demo
+`
+	require.NoError(t, os.WriteFile(os.Getenv("KUBECONFIG"), []byte(repointed), 0o600))
+
+	require.NoError(t, p.DeleteCluster(context.Background(), "demo", models.ClusterTypeGKE, false))
+
+	kubeconfig, err := os.ReadFile(os.Getenv("KUBECONFIG"))
+	require.NoError(t, err)
+	assert.Contains(t, string(kubeconfig), "somebody-elses.example", "a repointed context must survive delete")
+	assert.Contains(t, string(kubeconfig), "current-context: demo")
+}
+
+// TestPreflightNameCollision_FindsZonalClusters (П3): the collision check uses
+// a project-wide listing, so a zonal cluster with the same name (which a
+// region-scoped describe would miss) also counts.
+func TestPreflightNameCollision_FindsZonalClusters(t *testing.T) {
+	p, calls, _ := newTestProvider(t, nil)
+	mock := executor.NewMockCommandExecutor()
+	// clusters list output for a zonal cluster: same name, any location.
+	mock.SetResponse("clusters list --project my-project", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	p.executor = mock
+
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not managed by openframe")
+	assert.Empty(t, *calls)
 }

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -106,6 +106,55 @@ func (s *ClusterService) providerFor(clusterType models.ClusterType) (provider.P
 	return provider.New(clusterType, s.executor)
 }
 
+// shouldResumeCloudCreate decides whether an existing registry entry means
+// "reuse the cluster" or "resume an interrupted create". Cloud records exist
+// from the moment a workspace is scaffolded, so a non-Ready status marks a
+// create that failed or was interrupted — terraform apply resumes it
+// idempotently. Local k3d clusters only ever surface here when they actually
+// run, so they always reuse.
+func shouldResumeCloudCreate(clusterType models.ClusterType, status string) bool {
+	isCloud := clusterType == models.ClusterTypeEKS || clusterType == models.ClusterTypeGKE
+	return isCloud && status != "Ready"
+}
+
+// showExistingClusterReuse prints the "already exists" summary with the
+// cluster's REAL status and only k3d-specific rows for k3d clusters — this
+// box used to hardcode a green "Running" and a "k3d-<name>" network line for
+// every type, which was wrong for cloud clusters.
+func (s *ClusterService) showExistingClusterReuse(name string, info models.ClusterInfo) {
+	pterm.Warning.Printf("Cluster '%s' already exists!\n", pterm.Cyan(name))
+	pterm.DefaultBasicText.Println()
+
+	statusColor := ui.GetStatusColor(info.Status)
+	boxContent := fmt.Sprintf(
+		"NAME:     %s\n"+
+			"TYPE:     %s\n"+
+			"STATUS:   %s\n"+
+			"NODES:    %d",
+		pterm.Bold.Sprint(info.Name),
+		strings.ToUpper(string(info.Type)),
+		statusColor(info.Status),
+		info.NodeCount,
+	)
+	if info.Type == models.ClusterTypeK3d {
+		boxContent += fmt.Sprintf("\nNETWORK:  k3d-%s", info.Name)
+	}
+
+	pterm.DefaultBox.
+		WithTitle(" ⚠️  Cluster Already Exists  ⚠️ ").
+		WithTitleTopCenter().
+		Println(boxContent)
+
+	// Show what user can do (suppress for automation)
+	if !s.suppressUI {
+		pterm.DefaultBasicText.Println()
+		pterm.Info.Printf("What would you like to do?\n")
+		pterm.DefaultBasicText.Printf("  • Check status: openframe cluster status %s\n", name)
+		pterm.DefaultBasicText.Printf("  • Delete first: openframe cluster delete %s\n", name)
+		pterm.DefaultBasicText.Printf("  • Use different name: openframe cluster create my-new-cluster\n")
+	}
+}
+
 // CreateCluster handles cluster creation operations
 // Returns the *rest.Config for the created cluster that can be used to interact with it
 func (s *ClusterService) CreateCluster(ctx context.Context, config models.ClusterConfig) (*rest.Config, error) {
@@ -118,45 +167,22 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 
 	// Check if cluster already exists
 	if existingInfo, err := mgr.GetClusterStatus(ctx, config.Name); err == nil {
-		// Cluster already exists - show friendly message
-
-		// Show warning for existing cluster
-		pterm.Warning.Printf("Cluster '%s' already exists!\n", pterm.Cyan(config.Name))
-		pterm.DefaultBasicText.Println()
-
-		boxContent := fmt.Sprintf(
-			"NAME:     %s\n"+
-				"TYPE:     %s\n"+
-				"STATUS:   %s\n"+
-				"NODES:    %d\n"+
-				"NETWORK:  k3d-%s",
-			pterm.Bold.Sprint(existingInfo.Name),
-			strings.ToUpper(string(existingInfo.Type)),
-			pterm.Green("Running"),
-			existingInfo.NodeCount,
-			existingInfo.Name,
-		)
-
-		pterm.DefaultBox.
-			WithTitle(" ⚠️  Cluster Already Running  ⚠️ ").
-			WithTitleTopCenter().
-			Println(boxContent)
-
-		// Show what user can do (suppress for automation)
-		if !s.suppressUI {
-			pterm.DefaultBasicText.Println()
-			pterm.Info.Printf("What would you like to do?\n")
-			pterm.DefaultBasicText.Printf("  • Check status: openframe cluster status %s\n", config.Name)
-			pterm.DefaultBasicText.Printf("  • Delete first: openframe cluster delete %s\n", config.Name)
-			pterm.DefaultBasicText.Printf("  • Use different name: openframe cluster create my-new-cluster\n")
+		if shouldResumeCloudCreate(config.Type, existingInfo.Status) {
+			// A cloud workspace whose create failed or was interrupted: fall
+			// through to the provider, whose terraform apply resumes from the
+			// recorded state. The registry record must NOT short-circuit here —
+			// that made the documented "re-run create to resume" unreachable.
+			pterm.Info.Printf("Cluster '%s' has an interrupted creation (status: %s) — resuming\n",
+				config.Name, existingInfo.Status)
+		} else {
+			// Cluster already exists and is usable — reuse it.
+			s.showExistingClusterReuse(config.Name, existingInfo)
+			restConfig, err := mgr.GetRestConfig(ctx, config.Name)
+			if err != nil {
+				return nil, fmt.Errorf("cluster exists but failed to get REST config: %w", err)
+			}
+			return restConfig, nil // Exit gracefully without error
 		}
-
-		// Return the rest.Config for the existing cluster
-		restConfig, err := mgr.GetRestConfig(ctx, config.Name)
-		if err != nil {
-			return nil, fmt.Errorf("cluster exists but failed to get REST config: %w", err)
-		}
-		return restConfig, nil // Exit gracefully without error
 	}
 
 	// Cluster doesn't exist, proceed with creation. Cloud creates stream

--- a/internal/cluster/service_test.go
+++ b/internal/cluster/service_test.go
@@ -240,3 +240,28 @@ func TestClusterService_WithRealExecutor(t *testing.T) {
 	// Dry-run might still error if k3d is not available, which is acceptable in tests
 	_ = err
 }
+
+// TestShouldResumeCloudCreate locks the resume decision (audit П1): a cloud
+// registry record with a non-Ready status must RESUME through the provider,
+// not short-circuit into the "already exists" reuse path — that made the
+// documented "re-run create to resume" unreachable from the CLI.
+func TestShouldResumeCloudCreate(t *testing.T) {
+	cases := []struct {
+		clusterType models.ClusterType
+		status      string
+		want        bool
+	}{
+		{models.ClusterTypeGKE, "Failed", true},
+		{models.ClusterTypeGKE, "Creating", true},
+		{models.ClusterTypeGKE, "Ready", false},
+		{models.ClusterTypeEKS, "Failed", true},
+		{models.ClusterTypeEKS, "Ready", false},
+		{models.ClusterTypeK3d, "1/1", false},
+		{models.ClusterTypeK3d, "0/1", false},
+	}
+	for _, tc := range cases {
+		if got := shouldResumeCloudCreate(tc.clusterType, tc.status); got != tc.want {
+			t.Errorf("shouldResumeCloudCreate(%s, %q) = %v, want %v", tc.clusterType, tc.status, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Audit findings on idempotency/safety, all fixed:
- resume was unreachable through the CLI: any registry record (even status=failed) short-circuited into the "already exists" reuse path and errored on GetRestConfig. Non-Ready cloud records now fall through to the provider, whose terraform apply resumes from state (shouldResumeCloudCreate)
- the reuse box printed a hardcoded green "Running" and a k3d-<name> network line for every cluster type; it now shows the real status and k3d rows only for k3d
- the GKE name-collision preflight was region-scoped and missed zonal clusters; it now uses a project-wide clusters list --filter
- delete removed kubeconfig entries by name alone; it now only removes them when the context still points at the record's endpoint (mirror of the create-side no-clobber guard)