### PR TITLE
ci(test): exercise the full cloud-cluster command surface without creating one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,6 +345,61 @@ jobs:
           echo "==================================================================="
           "$OF_BIN" prerequisites check || echo "some prerequisites missing (expected pre-bootstrap)"
 
+      # Cloud-cluster command SURFACE, with no cloud and no Docker: the EKS
+      # coming-soon banner, flag validation, the GKE dry-run's graceful
+      # degradation, and `cluster use` error paths. Everything here is either
+      # exit-0 by design or an expected, asserted failure — no resource is
+      # ever created. Pure, so it runs on every OS (on Windows via the WSL
+      # forward, exercising the Linux binary's paths).
+      - name: 'Cluster: cloud command surface (no cloud, no Docker)'
+        shell: bash
+        run: |
+          echo "==================================================================="
+          echo "===  TEST: cloud cluster surface — banner, validation, dry-run, use"
+          echo "==================================================================="
+          fail() { echo "::error::$1"; exit 1; }
+
+          echo "--- EKS create is gated behind the coming-soon banner (exit 0)"
+          "$OF_BIN" cluster create eks-smoke --type eks --skip-wizard >/tmp/eks.out 2>&1 \
+            || { cat /tmp/eks.out; fail "eks banner path must exit 0"; }
+          grep -qi "coming soon" /tmp/eks.out || { cat /tmp/eks.out; fail "eks banner text missing"; }
+
+          echo "--- unknown --type is rejected"
+          if "$OF_BIN" cluster create x --type minikube --skip-wizard >/tmp/neg.out 2>&1; then
+            cat /tmp/neg.out; fail "unknown cluster type must be rejected"
+          fi
+          grep -q "unknown cluster type" /tmp/neg.out || { cat /tmp/neg.out; fail "missing unknown-type message"; }
+
+          echo "--- gke --skip-wizard demands --region and --project"
+          if "$OF_BIN" cluster create x --type gke --skip-wizard >/tmp/neg.out 2>&1; then
+            cat /tmp/neg.out; fail "gke without region/project must be rejected"
+          fi
+          grep -qE '\-\-(region|project) is required' /tmp/neg.out || { cat /tmp/neg.out; fail "missing required-flag message"; }
+
+          echo "--- gke dry-run degrades gracefully without terraform/credentials"
+          # Two legitimate outcomes on an unauthenticated runner: terraform absent
+          # -> soft skip (exit 0); terraform present -> the auth flow fails fast
+          # (non-interactive, exit non-zero). Both must be actionable, never a hang.
+          set +e
+          timeout 120 "$OF_BIN" cluster create gke-smoke --type gke \
+            --project no-such-project --region us-central1 --skip-wizard --dry-run </dev/null >/tmp/gke.out 2>&1
+          code=$?
+          set -e
+          [ "$code" -eq 124 ] && { cat /tmp/gke.out; fail "gke dry-run hung on a prompt"; }
+          grep -qiE "skipping the plan preview|not authenticated|not installed|application default|not accessible" /tmp/gke.out \
+            || { cat /tmp/gke.out; fail "gke dry-run produced neither a skip nor an auth hint (exit $code)"; }
+          echo "OK (exit $code)"
+
+          echo "--- cluster use of an unknown cluster is an actionable error"
+          set +e
+          timeout 60 "$OF_BIN" cluster use no-such-cluster </dev/null >/tmp/use.out 2>&1
+          code=$?
+          set -e
+          [ "$code" -eq 124 ] && { cat /tmp/use.out; fail "cluster use hung on a prompt"; }
+          [ "$code" -eq 0 ] && { cat /tmp/use.out; fail "cluster use of an unknown cluster must fail"; }
+          grep -qiE "not (known|found) locally|gcloud" /tmp/use.out || { cat /tmp/use.out; fail "missing actionable use error"; }
+          echo "cloud surface OK"
+
       # Everything below needs a Docker daemon + k3d. It runs on linux and on
       # windows (the Windows binary forwards into WSL, where Docker was started
       # above), exercising the real cluster lifecycle on both. darwin stays
@@ -359,6 +414,62 @@ jobs:
           "$OF_BIN" cluster list
           "$OF_BIN" cluster list -o json
           "$OF_BIN" cluster list -o yaml
+
+      # Managed-cloud OWNERSHIP GUARDS, exercised on the real binary against a
+      # fake GKE workspace (an isolated OPENFRAME_CLUSTERS_DIR with a
+      # hand-written cluster.json) — no cloud, no terraform, fully
+      # deterministic. Locks: registry-backed list/status, the typed-confirm
+      # refusal on non-interactive cloud delete, and use's missing-context
+      # error. Linux only: one leg suffices and the Windows binary would need
+      # the fake workspace inside WSL's home.
+      - name: 'Cluster: managed-cloud guards (fake workspace, no cloud)'
+        if: matrix.os == 'linux'
+        shell: bash
+        env:
+          OPENFRAME_CLUSTERS_DIR: ${{ runner.temp }}/of-fake-clusters
+        run: |
+          echo "==================================================================="
+          echo "===  TEST: cloud ownership guards on a fake GKE workspace"
+          echo "==================================================================="
+          fail() { echo "::error::$1"; exit 1; }
+          export KUBECONFIG="$RUNNER_TEMP/of-fake-kubeconfig"
+
+          mkdir -p "$OPENFRAME_CLUSTERS_DIR/fake-gke"
+          cat > "$OPENFRAME_CLUSTERS_DIR/fake-gke/cluster.json" <<'EOF'
+          {"name":"fake-gke","type":"gke","status":"ready","region":"us-central1",
+           "project":"fake-project","node_count":3,"created_at":"2026-07-22T00:00:00Z",
+           "endpoint":"https://203.0.113.10","ca_cert":"ZmFrZS1jYQ=="}
+          EOF
+
+          echo "--- the registry cluster appears in list with source=openframe"
+          "$OF_BIN" cluster list -o json | jq -e \
+            '.[] | select(.name == "fake-gke")' >/dev/null \
+            || fail "fake-gke missing from cluster list -o json"
+
+          echo "--- status resolves through the registry (no cloud calls)"
+          "$OF_BIN" cluster status fake-gke -o json | jq -e \
+            '.type == "gke"' >/dev/null || fail "status -o json lacks type gke"
+
+          echo "--- use without a kubeconfig context fails with the exact hint"
+          set +e
+          "$OF_BIN" cluster use fake-gke </dev/null >/tmp/use.out 2>&1
+          code=$?
+          set -e
+          [ "$code" -eq 0 ] && { cat /tmp/use.out; fail "use without a context must fail"; }
+          grep -q "no kubeconfig context" /tmp/use.out || { cat /tmp/use.out; fail "missing no-context hint"; }
+
+          echo "--- non-interactive cloud delete WITHOUT --force refuses (typed-confirm gate)"
+          set +e
+          timeout 60 "$OF_BIN" cluster delete fake-gke </dev/null >/tmp/del.out 2>&1
+          code=$?
+          set -e
+          [ "$code" -eq 124 ] && { cat /tmp/del.out; fail "cluster delete hung on a prompt"; }
+          [ "$code" -eq 0 ] && { cat /tmp/del.out; fail "non-interactive cloud delete without --force must refuse"; }
+          grep -q "refusing to destroy cloud cluster" /tmp/del.out || { cat /tmp/del.out; fail "missing refusal message"; }
+
+          echo "--- the workspace (the only pointer to billed resources) survived"
+          [ -f "$OPENFRAME_CLUSTERS_DIR/fake-gke/cluster.json" ] || fail "refused delete must not remove the workspace"
+          echo "ownership guards OK"
 
       # --- Medium: dry-run, still no real changes ----------------------------
       - name: 'CLI: dry-run create & install'

--- a/cmd/cluster/status_json_test.go
+++ b/cmd/cluster/status_json_test.go
@@ -13,7 +13,10 @@ import (
 func TestStatusCommandHasOutputFlag(t *testing.T) {
 	f := getStatusCmd().Flags().Lookup("output")
 	if f == nil {
+		// The explicit return keeps SA5011 happy on linters that lose the
+		// noreturn fact for t.Fatal.
 		t.Fatal("cluster status is missing the --output flag")
+		return
 	}
 	if f.Shorthand != "o" {
 		t.Fatalf("--output shorthand = %q, want %q", f.Shorthand, "o")

--- a/internal/chart/prerequisites/installer_test.go
+++ b/internal/chart/prerequisites/installer_test.go
@@ -9,6 +9,7 @@ func TestNewInstaller(t *testing.T) {
 
 	if installer == nil {
 		t.Fatal("Expected installer to be created")
+		return
 	}
 
 	if installer.checker == nil {

--- a/internal/cluster/prerequisites/checker_test.go
+++ b/internal/cluster/prerequisites/checker_test.go
@@ -110,6 +110,7 @@ func TestCheckerForClusterType(t *testing.T) {
 		checker := checkerForClusterType(tc.clusterType)
 		if checker == nil {
 			t.Fatalf("checkerForClusterType(%q) = nil, want a requirement set", tc.clusterType)
+			continue
 		}
 		got := names(checker)
 		if len(got) != len(tc.want) {

--- a/internal/cluster/prerequisites/installer_test.go
+++ b/internal/cluster/prerequisites/installer_test.go
@@ -9,6 +9,7 @@ func TestNewInstaller(t *testing.T) {
 
 	if installer == nil {
 		t.Fatal("Expected installer to be created")
+		return
 	}
 
 	if installer.checker == nil {

--- a/internal/cluster/service_test.go
+++ b/internal/cluster/service_test.go
@@ -32,6 +32,7 @@ func TestNewClusterService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewClusterService should not return nil")
+		return
 	}
 
 	if service.executor != exec {

--- a/internal/shared/config/system_test.go
+++ b/internal/shared/config/system_test.go
@@ -11,6 +11,7 @@ func TestNewSystemService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewSystemService should not return nil")
+		return
 	}
 
 	// Should have default log directory set


### PR DESCRIPTION
Two new steps in the test-cli job:
- cloud command surface (all OSes): EKS coming-soon banner, unknown-type and missing-flag validation, GKE dry-run's graceful degradation on an unauthenticated runner (soft-skip or fast auth error, never a hang), and `cluster use` error paths — every case asserted, nothing created
- managed-cloud ownership guards (linux): a fake GKE workspace in an isolated OPENFRAME_CLUSTERS_DIR drives registry-backed list/status, use's missing-context hint, and the typed-confirm refusal on non-interactive delete — verifying the workspace survives the refusal