### PR TITLE
feat(cluster): dry-run plan preview lists the planned resources

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -110,6 +110,9 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 		pterm.Success.Println("Plan: no changes — the cluster already matches this configuration")
 		return nil
 	}
+	for _, change := range summary.Changes {
+		pterm.DefaultBasicText.Printf("  %-3s %s\n", change.Action, change.Address)
+	}
 	pterm.Success.Printf("Plan: %d to add, %d to change, %d to destroy\n", summary.Add, summary.Change, summary.Destroy)
 	return nil
 }

--- a/docs/getting-started/gke-workflow.md
+++ b/docs/getting-started/gke-workflow.md
@@ -17,6 +17,11 @@ without registering the cluster:
 ```bash
 openframe cluster create my-gke --type gke \
   --project my-project --region us-central1 --skip-wizard --dry-run
+#   +   google_project_service.required["container.googleapis.com"]
+#   +   module.network.module.vpc.google_compute_network.network
+#   +   module.gke.google_container_cluster.primary
+#   +   module.gke.google_container_node_pool.pools["default"]
+#   ...
 # Plan: 27 to add, 0 to change, 0 to destroy
 ```
 

--- a/internal/cluster/providers/terraform/engine.go
+++ b/internal/cluster/providers/terraform/engine.go
@@ -117,11 +117,22 @@ func (e *Engine) Destroy(ctx context.Context, dir string) error {
 	return nil
 }
 
+// PlanChange is one resource-level action of a terraform plan, in
+// terraform's own diff notation: "+" create, "~" update, "-" destroy,
+// "-/+" replace.
+type PlanChange struct {
+	Action  string
+	Address string
+}
+
 // PlanSummary is the resource-change footprint of a terraform plan.
 type PlanSummary struct {
 	Add     int
 	Change  int
 	Destroy int
+	// Changes lists every planned resource action, in plan order — the counts
+	// alone don't tell the user WHAT would be created.
+	Changes []PlanChange
 }
 
 // HasChanges reports whether the plan would modify anything.
@@ -153,13 +164,17 @@ func (e *Engine) Plan(ctx context.Context, dir string) (PlanSummary, error) {
 		switch {
 		case rc.Change.Actions.Create():
 			summary.Add++
+			summary.Changes = append(summary.Changes, PlanChange{Action: "+", Address: rc.Address})
 		case rc.Change.Actions.Update():
 			summary.Change++
+			summary.Changes = append(summary.Changes, PlanChange{Action: "~", Address: rc.Address})
 		case rc.Change.Actions.Delete():
 			summary.Destroy++
+			summary.Changes = append(summary.Changes, PlanChange{Action: "-", Address: rc.Address})
 		case rc.Change.Actions.Replace():
 			summary.Add++
 			summary.Destroy++
+			summary.Changes = append(summary.Changes, PlanChange{Action: "-/+", Address: rc.Address})
 		}
 	}
 	return summary, nil

--- a/internal/cluster/providers/terraform/engine_test.go
+++ b/internal/cluster/providers/terraform/engine_test.go
@@ -94,26 +94,36 @@ func TestEngine_LifecycleCalls(t *testing.T) {
 	assert.Equal(t, []string{"init", "apply", "plan", "destroy", "output"}, f.calls)
 }
 
-// action builds a tfjson resource change with the given actions.
-func action(actions ...tfjson.Action) *tfjson.ResourceChange {
-	return &tfjson.ResourceChange{Change: &tfjson.Change{Actions: actions}}
+// action builds a tfjson resource change with the given address and actions.
+func action(address string, actions ...tfjson.Action) *tfjson.ResourceChange {
+	return &tfjson.ResourceChange{Address: address, Change: &tfjson.Change{Actions: actions}}
 }
 
-func TestEngine_PlanSummaryCountsActions(t *testing.T) {
+func TestEngine_PlanSummaryCountsAndListsActions(t *testing.T) {
 	f := &fakeRunner{
 		planChanges: true,
 		plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
-			action(tfjson.ActionCreate),
-			action(tfjson.ActionCreate),
-			action(tfjson.ActionUpdate),
-			action(tfjson.ActionDelete),
-			action(tfjson.ActionDelete, tfjson.ActionCreate), // replace
+			action("module.network.google_compute_network.vpc", tfjson.ActionCreate),
+			action("module.gke.google_container_cluster.primary", tfjson.ActionCreate),
+			action("module.gke.google_container_node_pool.pools", tfjson.ActionUpdate),
+			action("google_project_service.required", tfjson.ActionDelete),
+			action("module.gke.random_string.suffix", tfjson.ActionDelete, tfjson.ActionCreate), // replace
 		}},
 	}
 	summary, err := engineWith(f).Plan(context.Background(), t.TempDir())
 	require.NoError(t, err)
-	assert.Equal(t, PlanSummary{Add: 3, Change: 1, Destroy: 2}, summary)
+	assert.Equal(t, 3, summary.Add)
+	assert.Equal(t, 1, summary.Change)
+	assert.Equal(t, 2, summary.Destroy)
 	assert.True(t, summary.HasChanges())
+	// The per-resource listing preserves plan order and diff notation.
+	assert.Equal(t, []PlanChange{
+		{Action: "+", Address: "module.network.google_compute_network.vpc"},
+		{Action: "+", Address: "module.gke.google_container_cluster.primary"},
+		{Action: "~", Address: "module.gke.google_container_node_pool.pools"},
+		{Action: "-", Address: "google_project_service.required"},
+		{Action: "-/+", Address: "module.gke.random_string.suffix"},
+	}, summary.Changes)
 	assert.Contains(t, f.calls, "show")
 }
 


### PR DESCRIPTION
The counts alone ("12 to add") don't tell the user WHAT would be created. PlanSummary now carries per-resource changes in terraform's diff notation (+ / ~ / - / -/+ with the resource address, in plan order) and the cloud dry-run prints them above the summary line.