### PR TITLE
feat(cluster): optional infracost estimate; no hardcoded prices anywhere

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -114,7 +114,25 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 		pterm.DefaultBasicText.Printf("  %-3s %s\n", change.Action, change.Address)
 	}
 	pterm.Success.Printf("Plan: %d to add, %d to change, %d to destroy\n", summary.Add, summary.Change, summary.Destroy)
+	showCostEstimate(ctx, exec, config, summary)
 	return nil
+}
+
+// showCostEstimate prints a monthly estimate when infracost is installed and
+// working; otherwise it prints NO figures — only the abstract cost warning
+// with the provider's pricing page. Best-effort either way: cost information
+// never fails the preview.
+func showCostEstimate(ctx context.Context, exec executor.CommandExecutor, config models.ClusterConfig, summary terraform.PlanSummary) {
+	if terraform.InfracostAvailable() {
+		if cost, err := terraform.EstimateMonthlyCost(ctx, exec, summary.PlanJSON); err == nil {
+			pterm.Info.Printf("Estimated monthly cost (infracost): %s\n", cost)
+			return
+		} else if utils.GetGlobalFlags().Global.Verbose {
+			pterm.Debug.Printf("infracost estimate unavailable: %v\n", err)
+		}
+	}
+	pterm.Info.Println(ui.CostHint(config.Type))
+	pterm.Info.Println("Tip: install infracost (https://www.infracost.io/docs/) to see a monthly cost estimate here")
 }
 
 // showEKSComingSoonBanner is the temporary stub for AWS EKS creation.

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -11,9 +11,12 @@ the hood. The CLI installs its own verified Terraform binary and generates the
 infrastructure code for you — no Terraform knowledge required.
 
 > **Cost warning.** Cloud clusters create billed resources: a managed control
-> plane (~$73/month on both providers), VM nodes, and NAT/networking. The CLI
-> shows this warning before creating and requires you to re-type the cluster
-> name before deleting.
+> plane, VM nodes, and NAT/networking. The CLI shows a warning with the
+> provider's pricing page before creating — and, when
+> [infracost](https://www.infracost.io) is installed, a monthly estimate in
+> the `--dry-run` preview — and requires you to re-type the cluster name
+> before deleting. Pricing: [GKE](https://cloud.google.com/kubernetes-engine/pricing)
+> · [EKS](https://aws.amazon.com/eks/pricing/).
 
 ## Prerequisites
 

--- a/docs/getting-started/gke-workflow.md
+++ b/docs/getting-started/gke-workflow.md
@@ -5,9 +5,12 @@ the OpenFrame CLI. You need: the `openframe` binary, a Google account with
 access to a GCP project, and a browser for the login. Everything else —
 Terraform, gcloud, the auth plugin, credentials — the CLI sets up itself.
 
-> **Costs.** A GKE cluster bills real money (~$73/month cluster management
-> fee + VM nodes + networking). The CLI warns before creating and requires
-> re-typing the cluster name before deleting.
+> **Costs.** A GKE cluster bills real money: a cluster management fee, VM
+> nodes, and networking — see the
+> [GKE pricing page](https://cloud.google.com/kubernetes-engine/pricing).
+> With [infracost](https://www.infracost.io) installed, `--dry-run` shows a
+> monthly estimate. The CLI warns before creating and requires re-typing the
+> cluster name before deleting.
 
 ## 0. (Optional) Preview what would be created
 

--- a/internal/cluster/providers/terraform/cost.go
+++ b/internal/cluster/providers/terraform/cost.go
@@ -1,0 +1,70 @@
+package terraform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	sharedexec "github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+)
+
+// Cost estimation is strictly optional: when the infracost CLI
+// (https://www.infracost.io) is installed and configured, the dry-run plan
+// preview shows a monthly estimate; otherwise the CLI prints no figures at
+// all — only a pointer to the provider's pricing page. No pricing is ever
+// hardcoded.
+
+// InfracostAvailable reports whether the infracost binary is on PATH.
+func InfracostAvailable() bool {
+	_, err := exec.LookPath("infracost")
+	return err == nil
+}
+
+// infracostBreakdown is the subset of `infracost breakdown --format json`
+// this integration reads.
+type infracostBreakdown struct {
+	TotalMonthlyCost string `json:"totalMonthlyCost"`
+	Currency         string `json:"currency"`
+}
+
+// EstimateMonthlyCost runs infracost against a terraform plan JSON and
+// returns a human-readable monthly estimate (e.g. "142.53 USD"). Any failure
+// (missing API key, network, unparseable output) is returned as an error —
+// callers fall back to the abstract pricing hint, never to made-up numbers.
+func EstimateMonthlyCost(ctx context.Context, execer sharedexec.CommandExecutor, planJSON []byte) (string, error) {
+	if len(planJSON) == 0 {
+		return "", fmt.Errorf("no plan JSON to estimate from")
+	}
+	tmp, err := os.MkdirTemp("", "openframe-infracost-*")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	planPath := filepath.Join(tmp, "plan.json")
+	if err := os.WriteFile(planPath, planJSON, 0o600); err != nil {
+		return "", err
+	}
+
+	result, err := execer.Execute(ctx, "infracost", "breakdown",
+		"--path", planPath, "--format", "json", "--no-color")
+	if err != nil {
+		return "", fmt.Errorf("infracost breakdown failed: %w", err)
+	}
+	var breakdown infracostBreakdown
+	if err := json.Unmarshal([]byte(result.Stdout), &breakdown); err != nil {
+		return "", fmt.Errorf("unparseable infracost output: %w", err)
+	}
+	cost := strings.TrimSpace(breakdown.TotalMonthlyCost)
+	if cost == "" {
+		return "", fmt.Errorf("infracost reported no total monthly cost")
+	}
+	currency := breakdown.Currency
+	if currency == "" {
+		currency = "USD"
+	}
+	return cost + " " + currency, nil
+}

--- a/internal/cluster/providers/terraform/cost_test.go
+++ b/internal/cluster/providers/terraform/cost_test.go
@@ -1,0 +1,63 @@
+package terraform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateMonthlyCost(t *testing.T) {
+	planJSON := []byte(`{"format_version":"1.2"}`)
+
+	t.Run("parses the infracost total", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("infracost breakdown", &executor.CommandResult{
+			ExitCode: 0,
+			Stdout:   `{"totalMonthlyCost":"142.53","currency":"USD","projects":[]}`,
+		})
+
+		cost, err := EstimateMonthlyCost(context.Background(), mock, planJSON)
+		require.NoError(t, err)
+		assert.Equal(t, "142.53 USD", cost)
+		assert.True(t, mock.WasCommandExecuted("infracost breakdown"), "must invoke infracost breakdown")
+	})
+
+	t.Run("missing currency defaults to USD", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("infracost breakdown", &executor.CommandResult{
+			ExitCode: 0, Stdout: `{"totalMonthlyCost":"99.00"}`,
+		})
+		cost, err := EstimateMonthlyCost(context.Background(), mock, planJSON)
+		require.NoError(t, err)
+		assert.Equal(t, "99.00 USD", cost)
+	})
+
+	t.Run("infracost failure is an error, never a made-up number", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetShouldFail(true, "No INFRACOST_API_KEY environment variable is set")
+		_, err := EstimateMonthlyCost(context.Background(), mock, planJSON)
+		assert.Error(t, err)
+	})
+
+	t.Run("unparseable output is an error", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("infracost breakdown", &executor.CommandResult{ExitCode: 0, Stdout: "not json"})
+		_, err := EstimateMonthlyCost(context.Background(), mock, planJSON)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty total is an error", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("infracost breakdown", &executor.CommandResult{ExitCode: 0, Stdout: `{"currency":"USD"}`})
+		_, err := EstimateMonthlyCost(context.Background(), mock, planJSON)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty plan JSON is an error", func(t *testing.T) {
+		_, err := EstimateMonthlyCost(context.Background(), executor.NewMockCommandExecutor(), nil)
+		assert.Error(t, err)
+	})
+}

--- a/internal/cluster/providers/terraform/engine.go
+++ b/internal/cluster/providers/terraform/engine.go
@@ -133,6 +133,9 @@ type PlanSummary struct {
 	// Changes lists every planned resource action, in plan order — the counts
 	// alone don't tell the user WHAT would be created.
 	Changes []PlanChange
+	// PlanJSON is the machine-readable plan (terraform show -json), used by
+	// the optional infracost estimate. Empty when the plan has no changes.
+	PlanJSON []byte
 }
 
 // HasChanges reports whether the plan would modify anything.
@@ -160,6 +163,10 @@ func (e *Engine) Plan(ctx context.Context, dir string) (PlanSummary, error) {
 		return PlanSummary{}, fmt.Errorf("terraform show failed: %w", err)
 	}
 	var summary PlanSummary
+	// Best-effort: the JSON only feeds the optional cost estimate.
+	if data, err := json.Marshal(plan); err == nil {
+		summary.PlanJSON = data
+	}
 	for _, rc := range plan.ResourceChanges {
 		switch {
 		case rc.Change.Actions.Create():

--- a/internal/cluster/providers/terraform/engine_test.go
+++ b/internal/cluster/providers/terraform/engine_test.go
@@ -187,3 +187,16 @@ func TestStringOutput_WrongType(t *testing.T) {
 	_, err := StringOutput(map[string]json.RawMessage{"n": json.RawMessage(`42`)}, "n")
 	assert.ErrorContains(t, err, "is not a string")
 }
+
+func TestEngine_PlanCarriesPlanJSON(t *testing.T) {
+	f := &fakeRunner{
+		planChanges: true,
+		plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+			action("module.gke.google_container_cluster.primary", tfjson.ActionCreate),
+		}},
+	}
+	summary, err := engineWith(f).Plan(context.Background(), t.TempDir())
+	require.NoError(t, err)
+	// The machine-readable plan feeds the optional infracost estimate.
+	assert.Contains(t, string(summary.PlanJSON), "google_container_cluster.primary")
+}

--- a/internal/cluster/ui/prompts.go
+++ b/internal/cluster/ui/prompts.go
@@ -54,14 +54,16 @@ func selectFromList(prompt string, items []string) (int, string, error) {
 	return sharedUI.SelectFromList(prompt, items)
 }
 
-// CostHint is the running-cost warning shown for cloud cluster types. The
-// figures are deliberately rough baselines, not quotes.
+// CostHint is the running-cost warning shown for cloud cluster types. It
+// deliberately carries NO figures — real numbers come only from the optional
+// infracost estimate in the dry-run preview; otherwise the user gets the
+// provider's pricing page, never a stale hardcoded price.
 func CostHint(clusterType models.ClusterType) string {
 	switch clusterType {
 	case models.ClusterTypeEKS:
-		return "This creates billed AWS resources: EKS control plane (~$73/mo), EC2 nodes, and a NAT gateway (~$33/mo + traffic)"
+		return "This creates billed AWS resources (managed control plane, EC2 nodes, networking) — pricing: https://aws.amazon.com/eks/pricing/"
 	case models.ClusterTypeGKE:
-		return "This creates billed GCP resources: GKE cluster management fee (~$73/mo), VM nodes, and networking"
+		return "This creates billed GCP resources (managed control plane, VM nodes, networking) — pricing: https://cloud.google.com/kubernetes-engine/pricing"
 	default:
 		return "Cloud clusters create resources that incur costs"
 	}


### PR DESCRIPTION
- dry-run preview: when infracost is installed and working, print the monthly estimate computed from the plan JSON (PlanSummary now carries terraform's machine-readable plan); any infracost failure falls back silently — figures are never invented
- without infracost: an abstract cost warning plus the provider's pricing page and a tip to install infracost
- CostHint and the docs drop the stale $73/$33 hardcoded figures