### PR TITLE
feat(cluster): offer a verified infracost install in the dry-run preview

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -8,11 +8,13 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites"
+	infracostinstall "github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/infracost"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/provider"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -118,18 +120,56 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 	return nil
 }
 
-// showCostEstimate prints a monthly estimate when infracost is installed and
-// working; otherwise it prints NO figures — only the abstract cost warning
-// with the provider's pricing page. Best-effort either way: cost information
-// never fails the preview.
+// Seams for hermetic tests: availability probes the real PATH and the offer
+// runs a real verified download — neither may happen in unit tests.
+var (
+	infracostAvailableFn = terraform.InfracostAvailable
+	infracostOfferFn     = offerInfracostInstall
+)
+
+// offerInfracostInstall proposes the verified pinned infracost install in an
+// interactive session. It returns whether infracost is available afterwards.
+// The API key stays the user's one manual step: `infracost auth login`.
+func offerInfracostInstall() bool {
+	if sharedUI.IsNonInteractive() {
+		return false
+	}
+	confirmed, err := sharedUI.ConfirmActionInteractive(
+		"Install infracost (verified download) to see a monthly cost estimate?", true)
+	if err != nil || !confirmed {
+		return false
+	}
+	if err := infracostinstall.NewInstaller().Install(); err != nil {
+		pterm.Warning.Printf("infracost install failed: %v\n", err)
+		return false
+	}
+	return infracostAvailableFn()
+}
+
+// showCostEstimate prints a monthly estimate when infracost is available and
+// working — offering to install it first in interactive sessions. Otherwise
+// it prints NO figures, only the abstract cost warning with the provider's
+// pricing page. Best-effort either way: cost information never fails the
+// preview.
 func showCostEstimate(ctx context.Context, exec executor.CommandExecutor, config models.ClusterConfig, summary terraform.PlanSummary) {
-	if terraform.InfracostAvailable() {
-		if cost, err := terraform.EstimateMonthlyCost(ctx, exec, summary.PlanJSON); err == nil {
+	available := infracostAvailableFn()
+	if !available {
+		available = infracostOfferFn()
+	}
+	if available {
+		cost, err := terraform.EstimateMonthlyCost(ctx, exec, summary.PlanJSON)
+		if err == nil {
 			pterm.Info.Printf("Estimated monthly cost (infracost): %s\n", cost)
 			return
-		} else if utils.GetGlobalFlags().Global.Verbose {
-			pterm.Debug.Printf("infracost estimate unavailable: %v\n", err)
 		}
+		// infracost is installed but could not estimate — the usual cause is
+		// the missing (free) API key, the user's single manual step.
+		pterm.Info.Println("Cost estimate unavailable — if you haven't set up infracost yet, run 'infracost auth login' (free) and re-run")
+		if utils.GetGlobalFlags().Global.Verbose {
+			pterm.Debug.Printf("infracost estimate error: %v\n", err)
+		}
+		pterm.Info.Println(ui.CostHint(config.Type))
+		return
 	}
 	pterm.Info.Println(ui.CostHint(config.Type))
 	pterm.Info.Println("Tip: install infracost (https://www.infracost.io/docs/) to see a monthly cost estimate here")

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/utils"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
@@ -182,5 +183,77 @@ func TestRunCreateCluster_EKSShowsComingSoonBanner(t *testing.T) {
 	}
 	if called {
 		t.Fatal("eks must not reach the plan preview while gated")
+	}
+}
+
+// TestShowCostEstimate drives the infracost offer/estimate flow on seams —
+// no real PATH probe, download, or infracost invocation ever happens.
+func TestShowCostEstimate(t *testing.T) {
+	summary := terraform.PlanSummary{Add: 1, PlanJSON: []byte(`{"format_version":"1.2"}`)}
+	config := models.ClusterConfig{Name: "x", Type: models.ClusterTypeGKE, NodeCount: 1,
+		Cloud: &models.CloudConfig{Region: "us-central1", Project: "p"}}
+
+	override := func(t *testing.T, available bool, offer bool) (offered *bool) {
+		t.Helper()
+		offered = new(bool)
+		origAvail, origOffer := infracostAvailableFn, infracostOfferFn
+		infracostAvailableFn = func() bool { return available }
+		infracostOfferFn = func() bool { *offered = true; return offer }
+		t.Cleanup(func() { infracostAvailableFn, infracostOfferFn = origAvail, origOffer })
+		return offered
+	}
+
+	t.Run("unavailable and declined: no infracost invocation", func(t *testing.T) {
+		utils.InitGlobalFlags()
+		t.Cleanup(utils.ResetGlobalFlags)
+		offered := override(t, false, false)
+		mock := executor.NewMockCommandExecutor()
+
+		showCostEstimate(context.Background(), mock, config, summary)
+
+		if !*offered {
+			t.Fatal("the install offer must be made when infracost is unavailable")
+		}
+		if mock.WasCommandExecuted("infracost") {
+			t.Fatal("infracost must not run when unavailable and declined")
+		}
+	})
+
+	t.Run("offer accepted: estimate runs", func(t *testing.T) {
+		utils.InitGlobalFlags()
+		t.Cleanup(utils.ResetGlobalFlags)
+		override(t, false, true)
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("infracost breakdown", &executor.CommandResult{
+			ExitCode: 0, Stdout: `{"totalMonthlyCost":"120.00","currency":"USD"}`})
+
+		showCostEstimate(context.Background(), mock, config, summary)
+
+		if !mock.WasCommandExecuted("infracost breakdown") {
+			t.Fatal("estimate must run after an accepted install offer")
+		}
+	})
+
+	t.Run("available but estimate fails: no offer, graceful hint", func(t *testing.T) {
+		utils.InitGlobalFlags()
+		t.Cleanup(utils.ResetGlobalFlags)
+		offered := override(t, true, false)
+		mock := executor.NewMockCommandExecutor()
+		mock.SetShouldFail(true, "No INFRACOST_API_KEY environment variable is set")
+
+		showCostEstimate(context.Background(), mock, config, summary)
+
+		if *offered {
+			t.Fatal("no install offer when infracost is already available")
+		}
+	})
+}
+
+// TestOfferInfracostInstall_NonInteractiveNeverPrompts: CI sessions must not
+// hit the confirm prompt (nor a download).
+func TestOfferInfracostInstall_NonInteractiveNeverPrompts(t *testing.T) {
+	t.Setenv("CI", "true")
+	if offerInfracostInstall() {
+		t.Fatal("non-interactive sessions must not offer/install infracost")
 	}
 }

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -12,9 +12,10 @@ infrastructure code for you — no Terraform knowledge required.
 
 > **Cost warning.** Cloud clusters create billed resources: a managed control
 > plane, VM nodes, and NAT/networking. The CLI shows a warning with the
-> provider's pricing page before creating — and, when
-> [infracost](https://www.infracost.io) is installed, a monthly estimate in
-> the `--dry-run` preview — and requires you to re-type the cluster name
+> provider's pricing page before creating — and, in an interactive
+> `--dry-run` it offers to install [infracost](https://www.infracost.io)
+> (verified pinned download; one-time free `infracost auth login`) and shows
+> a monthly estimate — and requires you to re-type the cluster name
 > before deleting. Pricing: [GKE](https://cloud.google.com/kubernetes-engine/pricing)
 > · [EKS](https://aws.amazon.com/eks/pricing/).
 

--- a/docs/getting-started/gke-workflow.md
+++ b/docs/getting-started/gke-workflow.md
@@ -8,8 +8,10 @@ Terraform, gcloud, the auth plugin, credentials — the CLI sets up itself.
 > **Costs.** A GKE cluster bills real money: a cluster management fee, VM
 > nodes, and networking — see the
 > [GKE pricing page](https://cloud.google.com/kubernetes-engine/pricing).
-> With [infracost](https://www.infracost.io) installed, `--dry-run` shows a
-> monthly estimate. The CLI warns before creating and requires re-typing the
+> In an interactive `--dry-run`, the CLI offers to install
+> [infracost](https://www.infracost.io) (verified pinned download) and then
+> shows a monthly estimate — your only manual step is a one-time free
+> `infracost auth login`. The CLI warns before creating and requires re-typing the
 > cluster name before deleting.
 
 ## 0. (Optional) Preview what would be created

--- a/internal/cluster/prerequisites/infracost/infracost.go
+++ b/internal/cluster/prerequisites/infracost/infracost.go
@@ -1,0 +1,89 @@
+// Package infracost installs the OPTIONAL infracost CLI, which powers the
+// monthly cost estimate in the cloud dry-run preview. It is never a required
+// prerequisite: the CLI only OFFERS to install it, and estimates additionally
+// need the user to run `infracost auth login` once (free API key for
+// infracost's own pricing API — no cloud credentials are involved).
+package infracost
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/flamingo-stack/openframe-cli/internal/platform"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/download"
+	"github.com/pterm/pterm"
+)
+
+type Installer struct{}
+
+func NewInstaller() *Installer { return &Installer{} }
+
+func commandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
+}
+
+// IsInstalled reports whether a working infracost binary is reachable,
+// preferring the CLI-managed bin dir.
+func (i *Installer) IsInstalled() bool {
+	if binDir, err := download.UserBinDir(); err == nil {
+		download.PrependToPath(binDir)
+	}
+	if !commandExists("infracost") {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "infracost", "--version").Run() == nil
+}
+
+func (i *Installer) GetInstallHelp() string {
+	return platform.InstallHint("infracost")
+}
+
+// Install downloads the pinned infracost release, verifies its SHA256, and
+// installs it into ~/.openframe/bin. The archive member layout is irregular
+// (see the pin comment), hence the direct InstallVerifiedTarGz call.
+func (i *Installer) Install() error {
+	switch runtime.GOOS {
+	case "darwin", "linux", "windows":
+	default:
+		return fmt.Errorf("automatic infracost installation not supported on %s", runtime.GOOS)
+	}
+
+	asset, ok := download.Infracost.Asset(runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		return fmt.Errorf("no verified infracost %s asset for %s/%s", download.Infracost.Version, runtime.GOOS, runtime.GOARCH)
+	}
+	binDir, err := download.UserBinDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		return fmt.Errorf("creating %s: %w", binDir, err)
+	}
+
+	member := fmt.Sprintf("infracost-%s-%s", runtime.GOOS, runtime.GOARCH)
+	dest := filepath.Join(binDir, "infracost")
+	if runtime.GOOS == "windows" {
+		member = "infracost.exe"
+		dest += ".exe"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	fmt.Printf("Downloading verified infracost %s...\n", download.Infracost.Version)
+	if err := (download.Downloader{}).InstallVerifiedTarGz(ctx, asset, member, dest, 0o750); err != nil {
+		return fmt.Errorf("verified infracost install failed: %w", err)
+	}
+	download.PrependToPath(binDir)
+	pterm.Success.Printf("Installed verified infracost %s to %s\n", download.Infracost.Version, dest)
+	pterm.Info.Println("To enable estimates, get a free API key once: infracost auth login")
+	return nil
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -102,6 +102,12 @@ var toolDocs = map[string]InstallDocs{
 		Windows: "gke-gcloud-auth-plugin: Run 'gcloud components install gke-gcloud-auth-plugin'",
 		Default: "gke-gcloud-auth-plugin: See https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl",
 	},
+	"infracost": {
+		Darwin:  "infracost: The CLI can install a verified pinned binary automatically, or run 'brew install infracost'; enable estimates with 'infracost auth login'",
+		Linux:   "infracost: The CLI can install a verified pinned binary automatically (see https://www.infracost.io/docs/); enable estimates with 'infracost auth login'",
+		Windows: "infracost: The CLI can install a verified pinned binary automatically (see https://www.infracost.io/docs/); enable estimates with 'infracost auth login'",
+		Default: "infracost: See https://www.infracost.io/docs/ — enable estimates with 'infracost auth login'",
+	},
 	"aws": {
 		Darwin:  "AWS CLI: Run 'brew install awscli' or download from https://aws.amazon.com/cli/",
 		Linux:   "AWS CLI: Install via your package manager or from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html",

--- a/internal/shared/download/pins.go
+++ b/internal/shared/download/pins.go
@@ -126,6 +126,36 @@ var Terraform = PinnedTool{
 	},
 }
 
+// Infracost is the pinned infracost CLI, used by the OPTIONAL cost estimate
+// in the cloud dry-run preview. Upstream:
+// https://github.com/infracost/infracost/releases — .tar.gz per platform with
+// per-asset .sha256 files. The archive member layout is irregular
+// ("infracost-<os>-<arch>" on unix, "infracost.exe" on windows), so the
+// infracost installer extracts it itself via InstallVerifiedTarGz instead of
+// the InstallPinnedTool tarball convention.
+const (
+	infracostVersion = "v0.10.45"
+	infracostBaseURL = "https://github.com/infracost/infracost/releases/download/" + infracostVersion + "/infracost-"
+
+	infracostSHA256LinuxAMD64   = "e2f527d8391a87ac00bfc55237ff875107861715e234bbbeb9b6015aba576c77"
+	infracostSHA256LinuxARM64   = "b9946cf42b9ed58184bd646484f63e0ecf430caca5978e0611302a1545c36262"
+	infracostSHA256DarwinAMD64  = "b2202262267b704b95e786acfeb09c1f86e384e896ea42edb4de3f91a338a637"
+	infracostSHA256DarwinARM64  = "98b134ca825d292a34a410cdbfa0cfa0d3c9ec2b576710de0d051be6d9002771"
+	infracostSHA256WindowsAMD64 = "7f627fac5cad9b7260e1123c1378d2fb4f308cdc64f78e99d6e69727d9549d06"
+)
+
+var Infracost = PinnedTool{
+	Name:    "infracost",
+	Version: infracostVersion,
+	Assets: map[string]PinnedAsset{
+		"linux/amd64":   {URL: infracostBaseURL + "linux-amd64.tar.gz", SHA256: infracostSHA256LinuxAMD64},
+		"linux/arm64":   {URL: infracostBaseURL + "linux-arm64.tar.gz", SHA256: infracostSHA256LinuxARM64},
+		"darwin/amd64":  {URL: infracostBaseURL + "darwin-amd64.tar.gz", SHA256: infracostSHA256DarwinAMD64},
+		"darwin/arm64":  {URL: infracostBaseURL + "darwin-arm64.tar.gz", SHA256: infracostSHA256DarwinARM64},
+		"windows/amd64": {URL: infracostBaseURL + "windows-amd64.tar.gz", SHA256: infracostSHA256WindowsAMD64},
+	},
+}
+
 // UserBinDir returns the CLI-managed bin directory (~/.openframe/bin) where
 // verified tool binaries are installed. It does not create the directory.
 func UserBinDir() (string, error) {

--- a/internal/shared/download/pins_test.go
+++ b/internal/shared/download/pins_test.go
@@ -142,10 +142,10 @@ func TestPinnedAssets_RealDownload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("network test skipped under -short")
 	}
-	tools := []PinnedTool{Terraform}
+	tools := []PinnedTool{Terraform, Infracost}
 	if runtime.GOOS != "windows" {
 		// k3d/mkcert/helm have no windows pins: on Windows they run inside WSL.
-		// Terraform is pinned for all platforms.
+		// Terraform and infracost are pinned for all supported platforms.
 		tools = append(tools, K3d, Mkcert, Helm)
 	}
 	for _, tool := range tools {
@@ -306,5 +306,31 @@ func TestInstallPinnedTool_RealK3dExec(t *testing.T) {
 	}
 	if !strings.Contains(string(out), strings.TrimPrefix(K3d.Version, "v")) {
 		t.Fatalf("k3d version output %q does not contain %q", out, K3d.Version)
+	}
+}
+
+// TestInfracost_Pins locks the infracost pin shape: a versioned .tar.gz +
+// non-empty SHA256 for every supported platform (windows/arm64 has no
+// upstream asset).
+func TestInfracost_Pins(t *testing.T) {
+	if !strings.HasPrefix(Infracost.Version, "v") {
+		t.Fatalf("Infracost.Version must be a v-prefixed tag, got %q", Infracost.Version)
+	}
+	for _, p := range []struct{ os, arch string }{
+		{"linux", "amd64"}, {"linux", "arm64"},
+		{"darwin", "amd64"}, {"darwin", "arm64"},
+		{"windows", "amd64"},
+	} {
+		asset, ok := Infracost.Asset(p.os, p.arch)
+		if !ok {
+			t.Errorf("no infracost asset for %s/%s", p.os, p.arch)
+			continue
+		}
+		if len(asset.SHA256) != 64 {
+			t.Errorf("%s/%s: SHA256 must be 64 hex chars, got %q", p.os, p.arch, asset.SHA256)
+		}
+		if !strings.Contains(asset.URL, Infracost.Version) || !strings.HasSuffix(asset.URL, p.os+"-"+p.arch+".tar.gz") {
+			t.Errorf("%s/%s: URL %q must contain version and end with platform.tar.gz", p.os, p.arch, asset.URL)
+		}
 	}
 }


### PR DESCRIPTION
- pinned infracost v0.10.45 (all supported platforms, SHA256 from the release's per-asset checksums) installed into ~/.openframe/bin; the archive's irregular member layout is handled by a dedicated installer
- interactive dry-run without infracost now offers the install; the user's only manual step is a one-time free 'infracost auth login' (surfaced when an estimate fails without a key)
- non-interactive sessions never prompt or download; hermetic seam-based tests cover offer/accept/decline/failure paths