### PR TITLE
feat(cluster): run the one-time infracost auth login inside the CLI

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"os"
+	osexec "os/exec"
 	"strings"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
@@ -120,12 +122,38 @@ func cloudPlanPreview(ctx context.Context, config models.ClusterConfig) error {
 	return nil
 }
 
-// Seams for hermetic tests: availability probes the real PATH and the offer
-// runs a real verified download — neither may happen in unit tests.
+// Seams for hermetic tests: availability probes the real PATH, the offer runs
+// a real verified download, and the login launches a real browser flow — none
+// of that may happen in unit tests.
 var (
 	infracostAvailableFn = terraform.InfracostAvailable
 	infracostOfferFn     = offerInfracostInstall
+	infracostLoginFn     = offerInfracostLogin
 )
+
+// offerInfracostLogin runs the one-time `infracost auth login` (browser flow)
+// right inside the CLI, so the user never needs a separate console. Attached
+// straight to the terminal — the flow prints a URL and reads stdin, which the
+// capturing executor would swallow. Returns whether a login was performed.
+func offerInfracostLogin() bool {
+	if sharedUI.IsNonInteractive() {
+		return false
+	}
+	confirmed, err := sharedUI.ConfirmActionInteractive(
+		"infracost needs a one-time free API key. Run 'infracost auth login' now (opens a browser)?", true)
+	if err != nil || !confirmed {
+		return false
+	}
+	login := osexec.Command("infracost", "auth", "login")
+	login.Stdin = os.Stdin
+	login.Stdout = os.Stdout
+	login.Stderr = os.Stderr
+	if err := login.Run(); err != nil {
+		pterm.Warning.Printf("infracost auth login failed: %v\n", err)
+		return false
+	}
+	return true
+}
 
 // offerInfracostInstall proposes the verified pinned infracost install in an
 // interactive session. It returns whether infracost is available afterwards.
@@ -158,13 +186,16 @@ func showCostEstimate(ctx context.Context, exec executor.CommandExecutor, config
 	}
 	if available {
 		cost, err := terraform.EstimateMonthlyCost(ctx, exec, summary.PlanJSON)
+		if err != nil && infracostLoginFn() {
+			// The usual failure is the missing (free) API key. The login just
+			// ran inside the CLI — retry once.
+			cost, err = terraform.EstimateMonthlyCost(ctx, exec, summary.PlanJSON)
+		}
 		if err == nil {
 			pterm.Info.Printf("Estimated monthly cost (infracost): %s\n", cost)
 			return
 		}
-		// infracost is installed but could not estimate — the usual cause is
-		// the missing (free) API key, the user's single manual step.
-		pterm.Info.Println("Cost estimate unavailable — if you haven't set up infracost yet, run 'infracost auth login' (free) and re-run")
+		pterm.Info.Println("Cost estimate unavailable — run 'infracost auth login' (free, one-time) and re-run")
 		if utils.GetGlobalFlags().Global.Verbose {
 			pterm.Debug.Printf("infracost estimate error: %v\n", err)
 		}

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -234,10 +234,14 @@ func TestShowCostEstimate(t *testing.T) {
 		}
 	})
 
-	t.Run("available but estimate fails: no offer, graceful hint", func(t *testing.T) {
+	t.Run("available but estimate fails: login offered, declined -> hint", func(t *testing.T) {
 		utils.InitGlobalFlags()
 		t.Cleanup(utils.ResetGlobalFlags)
 		offered := override(t, true, false)
+		loginOffered := false
+		origLogin := infracostLoginFn
+		infracostLoginFn = func() bool { loginOffered = true; return false }
+		t.Cleanup(func() { infracostLoginFn = origLogin })
 		mock := executor.NewMockCommandExecutor()
 		mock.SetShouldFail(true, "No INFRACOST_API_KEY environment variable is set")
 
@@ -245,6 +249,33 @@ func TestShowCostEstimate(t *testing.T) {
 
 		if *offered {
 			t.Fatal("no install offer when infracost is already available")
+		}
+		if !loginOffered {
+			t.Fatal("a failed estimate must offer the in-CLI 'infracost auth login'")
+		}
+	})
+
+	t.Run("failed estimate + accepted login: estimate retried", func(t *testing.T) {
+		utils.InitGlobalFlags()
+		t.Cleanup(utils.ResetGlobalFlags)
+		override(t, true, false)
+		mock := executor.NewMockCommandExecutor()
+		// First breakdown fails (no key); the accepted login flips the mock to
+		// success, mimicking a real auth login taking effect.
+		mock.SetShouldFail(true, "No INFRACOST_API_KEY environment variable is set")
+		origLogin := infracostLoginFn
+		infracostLoginFn = func() bool {
+			mock.SetShouldFail(false, "")
+			mock.SetResponse("infracost breakdown", &executor.CommandResult{
+				ExitCode: 0, Stdout: `{"totalMonthlyCost":"120.00","currency":"USD"}`})
+			return true
+		}
+		t.Cleanup(func() { infracostLoginFn = origLogin })
+
+		showCostEstimate(context.Background(), mock, config, summary)
+
+		if mock.GetCommandCount() < 2 {
+			t.Fatalf("estimate must be retried after a successful login, got %d invocations", mock.GetCommandCount())
 		}
 	})
 }
@@ -255,5 +286,14 @@ func TestOfferInfracostInstall_NonInteractiveNeverPrompts(t *testing.T) {
 	t.Setenv("CI", "true")
 	if offerInfracostInstall() {
 		t.Fatal("non-interactive sessions must not offer/install infracost")
+	}
+}
+
+// TestOfferInfracostLogin_NonInteractiveNeverPrompts: CI sessions must not
+// hit the confirm prompt (nor a browser).
+func TestOfferInfracostLogin_NonInteractiveNeverPrompts(t *testing.T) {
+	t.Setenv("CI", "true")
+	if offerInfracostLogin() {
+		t.Fatal("non-interactive sessions must not run infracost auth login")
 	}
 }

--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -14,7 +14,7 @@ infrastructure code for you — no Terraform knowledge required.
 > plane, VM nodes, and NAT/networking. The CLI shows a warning with the
 > provider's pricing page before creating — and, in an interactive
 > `--dry-run` it offers to install [infracost](https://www.infracost.io)
-> (verified pinned download; one-time free `infracost auth login`) and shows
+> (verified pinned download; the one-time free `infracost auth login` is also offered in-CLI) and shows
 > a monthly estimate — and requires you to re-type the cluster name
 > before deleting. Pricing: [GKE](https://cloud.google.com/kubernetes-engine/pricing)
 > · [EKS](https://aws.amazon.com/eks/pricing/).

--- a/docs/getting-started/gke-workflow.md
+++ b/docs/getting-started/gke-workflow.md
@@ -10,8 +10,8 @@ Terraform, gcloud, the auth plugin, credentials — the CLI sets up itself.
 > [GKE pricing page](https://cloud.google.com/kubernetes-engine/pricing).
 > In an interactive `--dry-run`, the CLI offers to install
 > [infracost](https://www.infracost.io) (verified pinned download) and then
-> shows a monthly estimate — your only manual step is a one-time free
-> `infracost auth login`. The CLI warns before creating and requires re-typing the
+> shows a monthly estimate — even the one-time free
+> `infracost auth login` is offered right inside the CLI. The CLI warns before creating and requires re-typing the
 > cluster name before deleting.
 
 ## 0. (Optional) Preview what would be created


### PR DESCRIPTION
A failed estimate (typically the missing free API key) now offers to run 'infracost auth login' right there, attached to the terminal, and retries the estimate once after a successful login — no separate console needed. Non-interactive sessions never prompt; hermetic seam-based tests cover the declined, accepted-and-retried, and CI paths.