### PR TITLE
feat(cluster): terraform-apply-style plan confirmation before a real create

### DIFF
--- a/docs/getting-started/cloud-clusters.md
+++ b/docs/getting-started/cloud-clusters.md
@@ -61,7 +61,12 @@ Useful flags: `--machine-type`, `--min-nodes` / `--max-nodes`, `--spot`,
 `--profile` (AWS), `--nodes` (initial size), `--version` (`<major>.<minor>`,
 e.g. `1.33`).
 
-Provisioning takes ~10–20 minutes; the CLI streams per-resource progress.
+In interactive sessions the CLI first shows the full Terraform plan and asks
+for approval (the `terraform apply` shape; what you approve is exactly what
+runs — non-interactive sessions auto-approve). Provisioning then takes ~10–20
+minutes; the CLI streams per-resource progress. GKE nodes are private (no
+external IPs, egress via Cloud NAT) with a public control-plane endpoint, so
+the flow works in organizations enforcing `restrict_vm_external_ips`.
 When it finishes, your kubeconfig gets a context named after the cluster and
 it becomes the current context — `kubectl get nodes` just works
 (authentication runs through short-lived tokens via `aws eks get-token` /

--- a/docs/getting-started/gke-workflow.md
+++ b/docs/getting-started/gke-workflow.md
@@ -66,10 +66,19 @@ What happens, in order — no manual steps in between:
 3. **Preflight**: project access is verified, and the CLI refuses to proceed
    if a cluster with this name already exists in the project but was not
    created by openframe (it will never touch clusters it does not own).
-4. **Provision** (~10–15 min): a dedicated VPC with pod/service ranges and a
-   regional GKE cluster with an autoscaling node pool, streamed as
-   per-resource progress lines. Add `--verbose` for raw Terraform output.
-5. **Kubeconfig**: a context named exactly `my-gke` is merged into your
+4. **Plan & confirm** (interactive sessions): the full Terraform plan is
+   shown — every resource to be created and the summary line — and you are
+   asked to approve it before anything is applied, exactly like
+   `terraform apply`. What you approve is what runs (the saved plan is
+   applied, not a re-plan). Declining a brand-new create leaves no trace.
+   Non-interactive sessions auto-approve, as before.
+5. **Provision** (~10–15 min): required project APIs, a dedicated VPC with
+   pod/service ranges, a Cloud NAT for egress, and a regional GKE cluster
+   with **private nodes** (no external IPs — compatible with orgs enforcing
+   `restrict_vm_external_ips`) behind a public control-plane endpoint,
+   streamed as per-resource progress lines. Add `--verbose` for raw
+   Terraform output.
+6. **Kubeconfig**: a context named exactly `my-gke` is merged into your
    kubeconfig (existing contexts are never overwritten) and made current.
 
 ## 2. Verify

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -24,6 +24,10 @@ type Provider struct {
 	engine   *tfengine.Engine
 	registry *tfengine.Registry
 	executor executor.CommandExecutor
+	// confirmApply, when set, is asked before applying the create plan (the
+	// interactive `terraform apply` shape). Nil means auto-approve — the
+	// non-interactive/programmatic behavior and the test default.
+	confirmApply func(tfengine.PlanSummary) bool
 }
 
 // New builds the production provider. The registry defaults to
@@ -34,9 +38,10 @@ func New(exec executor.CommandExecutor, verbose bool) (*Provider, error) {
 		return nil, err
 	}
 	return &Provider{
-		engine:   tfengine.NewEngine(verbose),
-		registry: registry,
-		executor: exec,
+		engine:       tfengine.NewEngine(verbose),
+		registry:     registry,
+		executor:     exec,
+		confirmApply: tfengine.ConfirmApplyInteractive,
 	}, nil
 }
 
@@ -139,7 +144,8 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	}
 
 	ws := p.registry.Workspace(config.Name)
-	if !ws.Exists() {
+	freshWorkspace := !ws.Exists()
+	if freshWorkspace {
 		vars, err := tfvarsFor(config)
 		if err != nil {
 			return nil, err
@@ -182,7 +188,25 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 		_ = ws.SetStatus(tfengine.StatusFailed)
 		return nil, models.NewClusterOperationError("create", config.Name, err)
 	}
-	if err := p.engine.Apply(ctx, ws.TerraformDir()); err != nil {
+
+	// The `terraform apply` shape: plan, show, confirm, then apply the SAVED
+	// plan — what the user approved is exactly what runs.
+	summary, planFile, err := p.engine.PlanForApply(ctx, ws.TerraformDir())
+	if planFile != "" {
+		defer func() { _ = os.Remove(planFile) }()
+	}
+	if err != nil {
+		_ = ws.SetStatus(tfengine.StatusFailed)
+		return nil, models.NewClusterOperationError("create", config.Name, err)
+	}
+	if p.confirmApply != nil && !p.confirmApply(summary) {
+		if freshWorkspace {
+			// Nothing was applied — a declined brand-new create leaves no trace.
+			_ = ws.Remove()
+		}
+		return nil, fmt.Errorf("cluster creation cancelled — no changes were applied")
+	}
+	if err := p.engine.ApplyPlan(ctx, ws.TerraformDir(), planFile); err != nil {
 		_ = ws.SetStatus(tfengine.StatusFailed)
 		return nil, models.NewClusterOperationError("create", config.Name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run create to resume or 'openframe cluster delete %s' to tear down", err, ws.Dir(), config.Name))

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -163,8 +163,20 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 			}
 		}
 	}
-	// An existing workspace means a previous create failed or was interrupted;
-	// keep its tfvars (the state may reference them) and simply resume.
+	// An existing workspace means a previous create failed or was interrupted.
+	// Refresh the generated module from the CURRENT template before resuming:
+	// the retry must pick up template bugfixes (e.g. the private-nodes fix for
+	// org-policy environments), not replay the broken files. The state is
+	// untouched — terraform reconciles it against the refreshed config.
+	if ws.Exists() {
+		vars, err := tfvarsFor(config)
+		if err != nil {
+			return nil, err
+		}
+		if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := p.engine.Init(ctx, ws.TerraformDir()); err != nil {
 		_ = ws.SetStatus(tfengine.StatusFailed)

--- a/internal/cluster/providers/eks/provider_test.go
+++ b/internal/cluster/providers/eks/provider_test.go
@@ -101,7 +101,8 @@ func TestCreateCluster_HappyPath(t *testing.T) {
 
 	restConfig, err := p.CreateCluster(context.Background(), eksConfig("demo"))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"init", "apply", "output"}, *calls)
+	assert.Equal(t, []string{"init", "plan", "show", "apply", "output"}, *calls,
+		"create follows the terraform-apply shape: plan+show before the (auto-approved) apply")
 	assert.Equal(t, "https://demo.eks.example", restConfig.Host)
 	assert.Equal(t, []byte("fake-ca-pem"), restConfig.CAData)
 	require.NotNil(t, restConfig.ExecProvider)

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -25,6 +25,10 @@ type Provider struct {
 	engine   *tfengine.Engine
 	registry *tfengine.Registry
 	executor executor.CommandExecutor
+	// confirmApply, when set, is asked before applying the create plan (the
+	// interactive `terraform apply` shape). Nil means auto-approve — the
+	// non-interactive/programmatic behavior and the test default.
+	confirmApply func(tfengine.PlanSummary) bool
 }
 
 // New builds the production provider. The registry defaults to
@@ -35,9 +39,10 @@ func New(exec executor.CommandExecutor, verbose bool) (*Provider, error) {
 		return nil, err
 	}
 	return &Provider{
-		engine:   tfengine.NewEngine(verbose),
-		registry: registry,
-		executor: exec,
+		engine:       tfengine.NewEngine(verbose),
+		registry:     registry,
+		executor:     exec,
+		confirmApply: tfengine.ConfirmApplyInteractive,
 	}, nil
 }
 
@@ -156,9 +161,10 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	}
 
 	ws := p.registry.Workspace(config.Name)
+	freshWorkspace := !ws.Exists()
 	// The collision check only guards NEW clusters: an existing workspace means
 	// the cloud cluster (partial or complete) is ours and create resumes it.
-	if !ws.Exists() {
+	if freshWorkspace {
 		if err := p.preflightNameCollision(ctx, config); err != nil {
 			return nil, err
 		}
@@ -204,7 +210,25 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 		_ = ws.SetStatus(tfengine.StatusFailed)
 		return nil, models.NewClusterOperationError("create", config.Name, err)
 	}
-	if err := p.engine.Apply(ctx, ws.TerraformDir()); err != nil {
+
+	// The `terraform apply` shape: plan, show, confirm, then apply the SAVED
+	// plan — what the user approved is exactly what runs.
+	summary, planFile, err := p.engine.PlanForApply(ctx, ws.TerraformDir())
+	if planFile != "" {
+		defer func() { _ = os.Remove(planFile) }()
+	}
+	if err != nil {
+		_ = ws.SetStatus(tfengine.StatusFailed)
+		return nil, models.NewClusterOperationError("create", config.Name, err)
+	}
+	if p.confirmApply != nil && !p.confirmApply(summary) {
+		if freshWorkspace {
+			// Nothing was applied — a declined brand-new create leaves no trace.
+			_ = ws.Remove()
+		}
+		return nil, fmt.Errorf("cluster creation cancelled — no changes were applied")
+	}
+	if err := p.engine.ApplyPlan(ctx, ws.TerraformDir(), planFile); err != nil {
 		_ = ws.SetStatus(tfengine.StatusFailed)
 		return nil, models.NewClusterOperationError("create", config.Name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run create to resume or 'openframe cluster delete %s' to tear down", err, ws.Dir(), config.Name))

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -185,8 +185,20 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 			}
 		}
 	}
-	// An existing workspace means a previous create failed or was interrupted;
-	// keep its tfvars (the state may reference them) and simply resume.
+	// An existing workspace means a previous create failed or was interrupted.
+	// Refresh the generated module from the CURRENT template before resuming:
+	// the retry must pick up template bugfixes (e.g. the private-nodes fix for
+	// org-policy environments), not replay the broken files. The state is
+	// untouched — terraform reconciles it against the refreshed config.
+	if ws.Exists() {
+		vars, err := tfvarsFor(config)
+		if err != nil {
+			return nil, err
+		}
+		if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := p.engine.Init(ctx, ws.TerraformDir()); err != nil {
 		_ = ws.SetStatus(tfengine.StatusFailed)

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -106,7 +106,8 @@ func TestCreateCluster_HappyPath(t *testing.T) {
 
 	restConfig, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
 	require.NoError(t, err)
-	assert.Equal(t, []string{"init", "apply", "output"}, *calls)
+	assert.Equal(t, []string{"init", "plan", "show", "apply", "output"}, *calls,
+		"create follows the terraform-apply shape: plan+show before the (auto-approved) apply")
 	assert.Equal(t, "https://34.10.20.30", restConfig.Host, "bare module endpoint must be prefixed")
 	assert.Equal(t, []byte("fake-ca-pem"), restConfig.CAData)
 	require.NotNil(t, restConfig.ExecProvider)
@@ -425,4 +426,37 @@ func TestPreflightNameCollision_FindsZonalClusters(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not managed by openframe")
 	assert.Empty(t, *calls)
+}
+
+// TestCreateCluster_DeclinedPlanAppliesNothing: the interactive plan gate —
+// a declined plan must apply nothing, and a declined BRAND-NEW create must
+// leave no workspace behind (nothing exists to resume or bill).
+func TestCreateCluster_DeclinedPlanAppliesNothing(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+	p.confirmApply = func(summary tfengine.PlanSummary) bool { return false }
+
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+	assert.NotContains(t, *calls, "apply", "a declined plan must not apply")
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound, "declined brand-new create must remove the fresh workspace")
+}
+
+// TestCreateCluster_DeclinedResumeKeepsWorkspace: declining a RESUME keeps
+// the workspace — its state still points at real (billed) resources.
+func TestCreateCluster_DeclinedResumeKeepsWorkspace(t *testing.T) {
+	p, _, registry := newTestProvider(t, errors.New("first apply fails"))
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err) // failed create leaves a resumable workspace
+
+	p.confirmApply = func(summary tfengine.PlanSummary) bool { return false }
+	_, err = p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+
+	_, err = registry.Get("demo")
+	require.NoError(t, err, "declined resume must keep the workspace and its state")
 }

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -241,11 +241,36 @@ func TestTfvarsFor_VersionMapping(t *testing.T) {
 
 func TestTemplateEmbedsModulePins(t *testing.T) {
 	tf := string(mainTF)
-	assert.Contains(t, tf, `source  = "terraform-google-modules/kubernetes-engine/google"`)
+	assert.Contains(t, tf, `source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"`)
 	assert.Contains(t, tf, `version = "~> 44.0"`)
 	assert.Contains(t, tf, `source  = "terraform-google-modules/network/google"`)
 	assert.Contains(t, tf, `version = "~> 18.0"`)
 	assert.Contains(t, tf, "deletion_protection = false")
+	// Org-policy compatibility (restrict_vm_external_ips): private nodes with
+	// NAT egress and a public control-plane endpoint.
+	assert.Contains(t, tf, "enable_private_nodes    = true")
+	assert.Contains(t, tf, "enable_private_endpoint = false")
+	assert.Contains(t, tf, `resource "google_compute_router_nat" "nat"`)
+}
+
+// TestCreateCluster_ResumeRefreshesTemplate: a retry after a failed create
+// must regenerate main.tf from the CURRENT embedded template so template
+// bugfixes reach existing workspaces.
+func TestCreateCluster_ResumeRefreshesTemplate(t *testing.T) {
+	p, _, registry := newTestProvider(t, nil)
+	_, err := p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err)
+
+	// Simulate a stale workspace from an older CLI version.
+	stalePath := filepath.Join(registry.Workspace("demo").TerraformDir(), "main.tf")
+	require.NoError(t, os.WriteFile(stalePath, []byte("# stale broken template"), 0o600))
+
+	_, err = p.CreateCluster(context.Background(), gkeConfig("demo"))
+	require.NoError(t, err)
+
+	refreshed, err := os.ReadFile(stalePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(refreshed), "enable_private_nodes", "resume must rewrite main.tf from the current template")
 }
 
 func TestPlanCluster_NewClusterDoesNotRegister(t *testing.T) {

--- a/internal/cluster/providers/gke/templates/main.tf
+++ b/internal/cluster/providers/gke/templates/main.tf
@@ -100,8 +100,30 @@ module "network" {
   depends_on = [google_project_service.required]
 }
 
+# Private nodes have no external IPs (required by orgs enforcing the
+# constraints/compute.vmExternalIpAccess policy — a public-node pool lands in
+# ERROR state there), so egress (image pulls etc.) goes through Cloud NAT.
+resource "google_compute_router" "nat" {
+  name    = "${var.cluster_name}-router"
+  project = var.project
+  region  = var.region
+  network = module.network.network_name
+}
+
+resource "google_compute_router_nat" "nat" {
+  name    = "${var.cluster_name}-nat"
+  project = var.project
+  region  = var.region
+  router  = google_compute_router.nat.name
+
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
 module "gke" {
-  source  = "terraform-google-modules/kubernetes-engine/google"
+  # The private-cluster submodule: same interface as the root module plus the
+  # private-nodes controls the root module does not expose.
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   version = "~> 44.0"
 
   project_id = var.project
@@ -115,6 +137,13 @@ module "gke" {
   ip_range_services = "services"
 
   kubernetes_version = var.kubernetes_version != "" ? var.kubernetes_version : "latest"
+
+  # Nodes are private (no external IPs — org-policy friendly; egress via the
+  # Cloud NAT above). The API endpoint stays public so the operator's machine
+  # reaches the cluster without a VPN or Connect Gateway.
+  enable_private_nodes    = true
+  enable_private_endpoint = false
+  master_ipv4_cidr_block  = "172.16.0.0/28"
 
   # The CLI owns this cluster's lifecycle; deletion protection would break
   # 'openframe cluster delete'.

--- a/internal/cluster/providers/terraform/confirm.go
+++ b/internal/cluster/providers/terraform/confirm.go
@@ -1,0 +1,31 @@
+package terraform
+
+import (
+	"fmt"
+
+	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/pterm/pterm"
+)
+
+// ConfirmApplyInteractive is the default pre-apply gate for cluster creation
+// — the interactive `terraform apply` shape: show the full plan, then ask.
+// Non-interactive sessions auto-approve (the previous behavior of every
+// scripted/CI create), and a plan with no changes needs no question.
+func ConfirmApplyInteractive(summary PlanSummary) bool {
+	if !summary.HasChanges() {
+		return true
+	}
+	if sharedUI.IsNonInteractive() {
+		return true
+	}
+
+	pterm.DefaultBasicText.Println()
+	for _, change := range summary.Changes {
+		pterm.DefaultBasicText.Printf("  %-3s %s\n", change.Action, change.Address)
+	}
+	pterm.DefaultBasicText.Printf("\nPlan: %d to add, %d to change, %d to destroy\n\n", summary.Add, summary.Change, summary.Destroy)
+
+	confirmed, err := sharedUI.ConfirmActionInteractive(
+		fmt.Sprintf("Apply this plan (%d resources to add)?", summary.Add), true)
+	return err == nil && confirmed
+}

--- a/internal/cluster/providers/terraform/engine.go
+++ b/internal/cluster/providers/terraform/engine.go
@@ -144,23 +144,34 @@ func (s PlanSummary) HasChanges() bool { return s.Add+s.Change+s.Destroy > 0 }
 // Plan runs terraform plan in dir and summarizes the pending changes by
 // resource action (create/update/delete).
 func (e *Engine) Plan(ctx context.Context, dir string) (PlanSummary, error) {
+	summary, planFile, err := e.PlanForApply(ctx, dir)
+	if planFile != "" {
+		_ = os.Remove(planFile)
+	}
+	return summary, err
+}
+
+// PlanForApply plans dir and KEEPS the plan file for a subsequent ApplyPlan —
+// the interactive `terraform apply` shape: what was shown to the user is
+// EXACTLY what gets applied, with no re-plan drift in between. The caller
+// owns removing the returned plan file.
+func (e *Engine) PlanForApply(ctx context.Context, dir string) (PlanSummary, string, error) {
 	tf, err := e.newRunner(dir)
 	if err != nil {
-		return PlanSummary{}, err
+		return PlanSummary{}, "", err
 	}
 	planFile := filepath.Join(dir, "tfplan")
-	defer func() { _ = os.Remove(planFile) }()
 
 	changes, err := tf.Plan(ctx, tfexec.Out(planFile))
 	if err != nil {
-		return PlanSummary{}, fmt.Errorf("terraform plan failed: %w", err)
+		return PlanSummary{}, "", fmt.Errorf("terraform plan failed: %w", err)
 	}
 	if !changes {
-		return PlanSummary{}, nil
+		return PlanSummary{}, planFile, nil
 	}
 	plan, err := tf.ShowPlanFile(ctx, planFile)
 	if err != nil {
-		return PlanSummary{}, fmt.Errorf("terraform show failed: %w", err)
+		return PlanSummary{}, planFile, fmt.Errorf("terraform show failed: %w", err)
 	}
 	var summary PlanSummary
 	// Best-effort: the JSON only feeds the optional cost estimate.
@@ -184,7 +195,20 @@ func (e *Engine) Plan(ctx context.Context, dir string) (PlanSummary, error) {
 			summary.Changes = append(summary.Changes, PlanChange{Action: "-/+", Address: rc.Address})
 		}
 	}
-	return summary, nil
+	return summary, planFile, nil
+}
+
+// ApplyPlan applies a SAVED plan file produced by PlanForApply, streaming
+// per-resource progress like Apply.
+func (e *Engine) ApplyPlan(ctx context.Context, dir, planFile string) error {
+	tf, err := e.newRunner(dir)
+	if err != nil {
+		return err
+	}
+	if err := tf.ApplyJSON(ctx, newProgressWriter(e.verbose), tfexec.DirOrPlan(planFile)); err != nil {
+		return fmt.Errorf("terraform apply failed: %w", err)
+	}
+	return nil
 }
 
 // Outputs returns the root-module outputs of dir as raw JSON values.


### PR DESCRIPTION
    - create now plans, shows every resource with the summary, and asks for
      approval before applying — and applies the SAVED plan, so what the user
      approved is exactly what runs (PlanForApply/ApplyPlan in the engine)
    - declining a brand-new create removes the fresh workspace (nothing was
      applied); declining a resume keeps the workspace and its state
    - non-interactive sessions auto-approve, preserving scripted/CI behavior;
      a no-change plan asks nothing
    - docs: create flow updated (plan-confirm step, private nodes + NAT