### PR TITLE
fix: address external code-review findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,9 +367,10 @@ jobs:
             else "$@"; fi
           }
 
-          echo "--- EKS create is gated behind the coming-soon banner (exit 0)"
-          "$OF_BIN" cluster create eks-smoke --type eks --skip-wizard >/tmp/eks.out 2>&1 \
-            || { cat /tmp/eks.out; fail "eks banner path must exit 0"; }
+          echo "--- EKS create is gated: banner + non-zero exit (scripts must not see success)"
+          if "$OF_BIN" cluster create eks-smoke --type eks --skip-wizard >/tmp/eks.out 2>&1; then
+            cat /tmp/eks.out; fail "gated eks create must exit non-zero"
+          fi
           grep -qi "coming soon" /tmp/eks.out || { cat /tmp/eks.out; fail "eks banner text missing"; }
 
           echo "--- unknown --type is rejected"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Cluster lifecycle:
 
 ```bash
 openframe cluster create dev --type k3d --nodes 1 --skip-wizard
-openframe cluster create my-eks --type eks --region us-east-1 --skip-wizard   # cloud (billed!)
+openframe cluster create my-gke --type gke --project my-project --region us-central1 --skip-wizard  # cloud (billed!)
+openframe cluster create my-eks --type eks --skip-wizard    # EKS is gated: shows a coming-soon banner, creates nothing
 openframe cluster list                          # add -o json|yaml for scripts
 openframe cluster status dev
 openframe cluster delete dev --force

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -27,7 +27,7 @@ This command group provides cluster lifecycle management functionality:
   • use - Switch the kubectl context to a cluster
   • cleanup - Remove unused images and resources
 
-Supports K3d clusters for local development and AWS EKS for cloud deployments.
+Supports K3d clusters for local development and Google GKE for cloud deployments (AWS EKS coming soon).
 
 Examples:
   openframe cluster create

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -34,12 +34,13 @@ By default, shows a selection menu where you can choose:
 1. Quick start with defaults (press Enter) - creates cluster with default settings
 2. Interactive configuration wizard - step-by-step cluster customization
 
-Creates a local k3d cluster or a cloud EKS cluster for OpenFrame. If a cluster
+Creates a local k3d cluster or a cloud GKE cluster for OpenFrame (AWS EKS
+creation is temporarily disabled and coming soon). If a cluster
 with the same name already exists it is left untouched and reused — delete it
 first to start from scratch. Use the bootstrap command to install OpenFrame
 components after creation.
 
-EKS clusters are provisioned with Terraform (installed automatically) and
+Cloud clusters are provisioned with Terraform (installed automatically) and
 create AWS resources that incur costs; the workspace and state live under
 ~/.openframe/clusters/<name>. A failed create can be re-run to resume, or
 torn down with 'openframe cluster delete'.
@@ -49,7 +50,7 @@ Examples:
   openframe cluster create my-cluster        # Show selection with custom name
   openframe cluster create --skip-wizard     # Direct creation with defaults
   openframe cluster create --nodes 3 --type k3d --skip-wizard
-  openframe cluster create my-eks --type eks --region us-east-1 --skip-wizard`,
+  openframe cluster create my-gke --type gke --project my-project --region us-central1 --skip-wizard`,
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			utils.SyncGlobalFlags()
@@ -300,7 +301,9 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 	// creates are gated.
 	if config.Type == models.ClusterTypeEKS {
 		showEKSComingSoonBanner()
-		return nil
+		// Non-zero on purpose: a scripted `--type eks` must not look like a
+		// successful create when nothing was provisioned.
+		return fmt.Errorf("AWS EKS cluster creation is coming soon — use --type gke or k3d for now")
 	}
 
 	// Show configuration summary for dry-run or skip-wizard modes

--- a/cmd/cluster/create_behavior_test.go
+++ b/cmd/cluster/create_behavior_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
@@ -178,8 +179,12 @@ func TestRunCreateCluster_EKSShowsComingSoonBanner(t *testing.T) {
 	gf.Create.SkipWizard = true
 	gf.Create.ClusterType = "eks"
 
-	if err := runCreateCluster(cmd, []string{"cloud-cluster"}); err != nil {
-		t.Fatalf("eks banner path must return nil, got %v", err)
+	err := runCreateCluster(cmd, []string{"cloud-cluster"})
+	if err == nil {
+		t.Fatal("gated eks create must exit non-zero — a script must not mistake the banner for success")
+	}
+	if !strings.Contains(err.Error(), "coming soon") {
+		t.Fatalf("expected an actionable coming-soon error, got: %v", err)
 	}
 	if called {
 		t.Fatal("eks must not reach the plan preview while gated")

--- a/cmd/cluster/list.go
+++ b/cmd/cluster/list.go
@@ -123,7 +123,9 @@ func discoverExternalClusters(ctx context.Context, managed []models.ClusterInfo)
 
 	isManaged := func(c models.ClusterInfo) bool {
 		for _, m := range managed {
-			if m.Name == c.Name && (m.Project == "" || m.Project == c.Project) {
+			// Project-aware: a local k3d cluster (empty Project) must not
+			// suppress an external GKE cluster that merely shares its name.
+			if m.Name == c.Name && m.Project == c.Project {
 				return true
 			}
 		}

--- a/cmd/cluster/use.go
+++ b/cmd/cluster/use.go
@@ -129,8 +129,10 @@ func useExternalGKE(ctx context.Context, exec executor.CommandExecutor, kubeconf
 	if contextName == "" {
 		// No kubeconfig entry yet — fetch credentials (adds the gke_* context).
 		pterm.Info.Printf("Fetching credentials for '%s' (project %s, %s)...\n", name, found.Project, found.Region)
+		// --location (not --region): discovery's Region field carries the GKE
+		// location, which is a ZONE for zonal clusters.
 		if _, err := exec.Execute(ctx, "gcloud", "container", "clusters", "get-credentials", name,
-			"--project", found.Project, "--region", found.Region); err != nil {
+			"--project", found.Project, "--location", found.Region); err != nil {
 			return fmt.Errorf("could not fetch credentials for '%s' (for private clusters try 'gcloud container fleet memberships get-credentials %s'): %w", name, name, err)
 		}
 		contextName = fmt.Sprintf("gke_%s_%s_%s", found.Project, found.Region, name)

--- a/cmd/cluster/use_test.go
+++ b/cmd/cluster/use_test.go
@@ -115,9 +115,10 @@ func TestRunUseCluster_ExternalGKEFetchesCredentials(t *testing.T) {
 
 	err := runUseCluster(getUseCmd(), []string{"ext-1"})
 	// The mock cannot actually write the gke_* context, so the switch fails —
-	// but the credentials fetch must have been attempted first.
-	if !mock.WasCommandExecuted("gcloud container clusters get-credentials ext-1") {
-		t.Fatal("expected a get-credentials attempt for a context-less external cluster")
+	// but the credentials fetch must have been attempted first, with
+	// --location (which accepts both regions and zones).
+	if !mock.WasCommandExecuted("gcloud container clusters get-credentials ext-1 --project proj-x --location us-central1") {
+		t.Fatalf("expected a --location get-credentials attempt, got: %v", mock.GetExecutedCommands())
 	}
 	if err == nil || !strings.Contains(err.Error(), "no kubeconfig context") {
 		t.Fatalf("expected a missing-context error after mock fetch, got: %v", err)
@@ -133,5 +134,27 @@ func TestRunUseCluster_NotAuthenticatedIsActionable(t *testing.T) {
 	err := runUseCluster(getUseCmd(), []string{"ghost"})
 	if err == nil || !strings.Contains(err.Error(), "gcloud auth login") {
 		t.Fatalf("expected an auth hint, got: %v", err)
+	}
+}
+
+// TestRunUseCluster_ExternalZonalGKEFetchesByLocation: a ZONAL cluster's
+// location is a zone — get-credentials must receive it via --location, where
+// --region would fail.
+func TestRunUseCluster_ExternalZonalGKEFetchesByLocation(t *testing.T) {
+	mock := setupUse(t)
+	writeUseKubeconfig(t, "other", "other")
+	mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	mock.SetResponse("gcloud config configurations list", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"dev-x","properties":{"core":{"project":"proj-x"}}}]`})
+	mock.SetResponse("clusters list --project proj-x", &executor.CommandResult{ExitCode: 0,
+		Stdout: `[{"name":"zonal-1","location":"us-central1-a","status":"RUNNING","currentNodeCount":1}]`})
+	mock.SetResponse("k3d cluster get zonal-1", &executor.CommandResult{ExitCode: 1, Stderr: "not found"})
+
+	err := runUseCluster(getUseCmd(), []string{"zonal-1"})
+	if !mock.WasCommandExecuted("gcloud container clusters get-credentials zonal-1 --project proj-x --location us-central1-a") {
+		t.Fatalf("expected a zone-valued --location fetch, got: %v", mock.GetExecutedCommands())
+	}
+	if err == nil || !strings.Contains(err.Error(), "no kubeconfig context") {
+		t.Fatalf("expected a missing-context error after mock fetch, got: %v", err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,7 @@ for CLI design with wizard-style interactive prompts.
 
 Key Features:
   - Interactive Wizard - Step-by-step guided setup
-  - Cluster Management - local K3d clusters (cloud providers planned)
+  - Cluster Management - local K3d and cloud GKE clusters (AWS EKS coming soon)
   - Helm Integration - App-of-Apps pattern with ArgoCD
   - Prerequisite Checking - Validates tools before running
 

--- a/internal/cluster/models/flags.go
+++ b/internal/cluster/models/flags.go
@@ -174,8 +174,14 @@ func ValidateCreateFlags(flags *CreateFlags) error {
 			return fmt.Errorf("--project is required for --type gke with --skip-wizard")
 		}
 	}
-	if flags.BackendConfig != "" && !isCloud {
-		return fmt.Errorf("--backend-config only applies to cloud cluster types (eks, gke)")
+	if !isCloud {
+		switch {
+		case flags.BackendConfig != "":
+			return fmt.Errorf("--backend-config only applies to cloud cluster types (eks, gke)")
+		case flags.Region != "" || flags.Profile != "" || flags.Project != "" ||
+			flags.MachineType != "" || flags.MinNodes != 0 || flags.MaxNodes != 0 || flags.Spot:
+			return fmt.Errorf("--region/--profile/--project/--machine-type/--min-nodes/--max-nodes/--spot only apply to cloud cluster types (eks, gke)")
+		}
 	}
 	if flags.MinNodes < 0 || flags.MaxNodes < 0 {
 		return fmt.Errorf("node bounds must not be negative: min=%d max=%d", flags.MinNodes, flags.MaxNodes)

--- a/internal/cluster/provider/provider.go
+++ b/internal/cluster/provider/provider.go
@@ -1,10 +1,9 @@
 // Package provider defines the unified cluster-provider abstraction.
 //
-// A Provider creates and manages Kubernetes clusters. Today only k3d (local) is
-// implemented; for the recognized cloud types (GKE, EKS) the factory returns
-// ErrProviderNotFound until their backends land. New backends implement the
-// same Provider interface, so the rest of the CLI never needs to know which
-// backend is used.
+// A Provider creates and manages Kubernetes clusters. Three backends are
+// implemented — k3d (local), EKS, and GKE — all selected through the New
+// factory, keyed on the cluster type. Backends implement the same Provider
+// interface, so the rest of the CLI never needs to know which one runs.
 package provider
 
 import (

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -128,6 +128,25 @@ func (p *Provider) PlanCluster(ctx context.Context, config models.ClusterConfig)
 	return p.engine.Plan(ctx, dir)
 }
 
+// preflightNameCollision refuses to create a cluster whose name already
+// exists in the target account/region but has no openframe workspace —
+// terraform would build the VPC first and fail mid-apply on the duplicate
+// cluster, leaving partial billed infrastructure (the GKE twin's rationale).
+// Existence criterion: describe exits 0 AND prints exactly the name.
+func (p *Provider) preflightNameCollision(ctx context.Context, config models.ClusterConfig) error {
+	args := []string{"eks", "describe-cluster", "--name", config.Name,
+		"--region", config.Cloud.Region, "--query", "cluster.name", "--output", "text"}
+	if config.Cloud.Profile != "" {
+		args = append(args, "--profile", config.Cloud.Profile)
+	}
+	result, err := p.executor.Execute(ctx, "aws", args...)
+	if err != nil || result == nil || strings.TrimSpace(result.Stdout) != config.Name {
+		return nil // not found (or indeterminate) — proceed
+	}
+	return fmt.Errorf("cluster '%s' already exists in region '%s' but is not managed by openframe — refusing to touch it; pick another cluster name",
+		config.Name, config.Cloud.Region)
+}
+
 // CreateCluster provisions the cluster and returns a rest.Config for it.
 // Re-running after a failed apply resumes the same workspace: terraform apply
 // is idempotent over the recorded state.
@@ -146,6 +165,9 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	ws := p.registry.Workspace(config.Name)
 	freshWorkspace := !ws.Exists()
 	if freshWorkspace {
+		if err := p.preflightNameCollision(ctx, config); err != nil {
+			return nil, err
+		}
 		vars, err := tfvarsFor(config)
 		if err != nil {
 			return nil, err

--- a/internal/cluster/providers/eks/provider_test.go
+++ b/internal/cluster/providers/eks/provider_test.go
@@ -292,3 +292,37 @@ func TestCreateCluster_RejectsGCSBackend(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be s3://")
 	assert.Empty(t, *calls)
 }
+
+// TestCreateCluster_RefusesExternalNameCollision mirrors the GKE guard: an
+// unmanaged same-name EKS cluster in the account must block create BEFORE
+// terraform runs.
+func TestCreateCluster_RefusesExternalNameCollision(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("eks describe-cluster --name demo", &executor.CommandResult{ExitCode: 0, Stdout: "demo\n"})
+	p.executor = mock
+
+	_, err := p.CreateCluster(context.Background(), eksConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not managed by openframe")
+	assert.Empty(t, *calls, "terraform must not run on a name collision")
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound)
+}
+
+// TestCreateCluster_DeclinedPlanAppliesNothing mirrors the GKE decline gate.
+func TestCreateCluster_DeclinedPlanAppliesNothing(t *testing.T) {
+	p, calls, registry := newTestProvider(t, nil)
+	p.confirmApply = func(summary tfengine.PlanSummary) bool { return false }
+
+	_, err := p.CreateCluster(context.Background(), eksConfig("demo"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+	assert.NotContains(t, *calls, "apply")
+
+	_, err = registry.Get("demo")
+	var notFound models.ErrClusterNotFound
+	assert.ErrorAs(t, err, &notFound, "declined brand-new create must remove the fresh workspace")
+}

--- a/internal/cluster/providers/eks/templates/main.tf
+++ b/internal/cluster/providers/eks/templates/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.52"
+      version = ">= 6.52, < 7.0"
     }
   }
 }

--- a/internal/cluster/providers/gke/templates/main.tf
+++ b/internal/cluster/providers/gke/templates/main.tf
@@ -162,6 +162,10 @@ module "gke" {
       disk_size_gb       = 100
     }
   ]
+
+  # Private nodes need the NAT for egress (image pulls) from the first boot —
+  # nothing else creates an implicit ordering on it.
+  depends_on = [google_compute_router_nat.nat]
 }
 
 output "cluster_name" {

--- a/internal/cluster/providers/terraform/confirm.go
+++ b/internal/cluster/providers/terraform/confirm.go
@@ -26,6 +26,7 @@ func ConfirmApplyInteractive(summary PlanSummary) bool {
 	pterm.DefaultBasicText.Printf("\nPlan: %d to add, %d to change, %d to destroy\n\n", summary.Add, summary.Change, summary.Destroy)
 
 	confirmed, err := sharedUI.ConfirmActionInteractive(
-		fmt.Sprintf("Apply this plan (%d resources to add)?", summary.Add), true)
+		fmt.Sprintf("Apply this plan (%d to add, %d to change, %d to destroy)?",
+			summary.Add, summary.Change, summary.Destroy), true)
 	return err == nil && confirmed
 }

--- a/internal/cluster/providers/terraform/cost.go
+++ b/internal/cluster/providers/terraform/cost.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	sharedexec "github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 )
@@ -49,6 +50,11 @@ func EstimateMonthlyCost(ctx context.Context, execer sharedexec.CommandExecutor,
 		return "", err
 	}
 
+	// A local bound: infracost calls its pricing API over the network, and a
+	// hang here must never stall the dry-run preview (the parent ctx may have
+	// no deadline).
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
 	result, err := execer.Execute(ctx, "infracost", "breakdown",
 		"--path", planPath, "--format", "json", "--no-color")
 	if err != nil {

--- a/internal/cluster/providers/terraform/workspace.go
+++ b/internal/cluster/providers/terraform/workspace.go
@@ -125,13 +125,37 @@ func (w *Workspace) ReadRecord() (Record, error) {
 	return r, nil
 }
 
-// WriteRecord persists cluster.json atomically enough for a single-user CLI.
+// WriteRecord persists cluster.json via temp-file + atomic rename, so a
+// crash mid-write can never leave a truncated record — the record is the
+// registry's only pointer to the cluster.
 func (w *Workspace) WriteRecord(r Record) error {
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(w.dir, recordFile), data, 0o600)
+	tmp, err := os.CreateTemp(w.dir, ".record-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, filepath.Join(w.dir, recordFile)); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }
 
 // SetStatus updates only the lifecycle status in the record.

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -280,7 +280,10 @@ func (s *ClusterService) ListClusters() ([]models.ClusterInfo, error) {
 	for _, cloud := range s.cloudProviders() {
 		cloudClusters, err := cloud.ListAllClusters(ctx)
 		if err != nil {
-			return nil, err
+			// A broken cloud registry (local file damage) must not hide the
+			// local clusters or the other provider's results.
+			pterm.Debug.Printf("cloud cluster listing skipped: %v\n", err)
+			continue
 		}
 		clusters = append(clusters, cloudClusters...)
 	}

--- a/internal/cluster/ui/wizard.go
+++ b/internal/cluster/ui/wizard.go
@@ -90,9 +90,9 @@ func (w *ConfigWizard) Run() (ClusterConfig, error) {
 	// list below is meaningless for cloud clusters, whose version comes from
 	// the module default.
 	if clusterType == models.ClusterTypeEKS || clusterType == models.ClusterTypeGKE {
-		defaultRegion, defaultMachine := "us-east-1", "m6i.large"
+		regionLabel, defaultRegion, defaultMachine := "AWS Region", "us-east-1", "m6i.large"
 		if clusterType == models.ClusterTypeGKE {
-			defaultRegion, defaultMachine = "us-central1", "e2-standard-4"
+			regionLabel, defaultRegion, defaultMachine = "GCP Region", "us-central1", "e2-standard-4"
 
 			project, err := steps.PromptProject()
 			if err != nil {
@@ -101,7 +101,7 @@ func (w *ConfigWizard) Run() (ClusterConfig, error) {
 			w.config.Project = project
 		}
 
-		region, err := steps.PromptRegion(defaultRegion)
+		region, err := steps.PromptRegion(regionLabel, defaultRegion)
 		if err != nil {
 			return ClusterConfig{}, err
 		}

--- a/internal/cluster/ui/wizard_steps.go
+++ b/internal/cluster/ui/wizard_steps.go
@@ -90,10 +90,11 @@ func (ws *WizardSteps) PromptProject() (string, error) {
 	return strings.TrimSpace(result), nil
 }
 
-// PromptRegion prompts for the AWS region an EKS cluster lands in.
-func (ws *WizardSteps) PromptRegion(defaultRegion string) (string, error) {
+// PromptRegion prompts for the cloud region a cluster lands in; the label is
+// provider-specific ("GCP Region" / "AWS Region").
+func (ws *WizardSteps) PromptRegion(label, defaultRegion string) (string, error) {
 	prompt := promptui.Prompt{
-		Label:    "AWS Region",
+		Label:    label,
 		Default:  defaultRegion,
 		Validate: sharedUI.ValidateNonEmpty("region"),
 	}


### PR DESCRIPTION
- create: gated EKS create now exits non-zero with an actionable coming-soon error (scripts must not see success); help texts updated
- list: isManaged match is project-aware so a k3d cluster no longer shadows a same-name external GKE cluster
- use: get-credentials uses --location (works for zonal clusters too)
- gke: module depends_on Cloud NAT so nodes can pull images on boot
- eks: preflight name-collision guard (mirrors GKE); aws provider pinned '>= 6.52, < 7.0'
- terraform: apply prompt shows full plan counts; infracost run capped at 60s; cluster.json written atomically (temp file + rename)
- flags: non-cloud types reject all cloud-only flags
- service: ListClusters degrades gracefully when a cloud provider errors instead of failing the whole listing
- wizard: region prompt labeled per provider (GCP Region / AWS Region)
- tests: EKS banner error + CI step expect non-zero exit; zonal use test; EKS collision + declined-plan tests