### PR TITLE
chore: stop ignoring inline doc stubs (.*.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,17 @@ coverage.html
 .DS_Store
 Thumbs.db
 
-# Generated per-file doc stubs (external doc-orchestrator bot). All documentation
-# lives in docs/; these hidden .md files next to source must not be committed.
-.*.md
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ DO NOT ignore hidden `.*.md` files. NEVER re-add a `.*.md` rule here.     │
+# └──────────────────────────────────────────────────────────────────────────┘
+# The per-file inline doc stubs written next to source by the Flamingo AI
+# Technical Writer ARE first-class source. They are meant to be committed,
+# reviewed in the PR, and kept in sync with the code they sit beside.
+#
+# A `.*.md` rule was added in #212 and had to be reverted: besides discarding
+# the docs, it also matched the orchestrator's own run status file
+# (`.flamingo-ai-technical-writer-status.md`) and hard-failed every workflow
+# run at branch creation before any documentation was generated.
+#
+# If these files ever feel like noise, fix it upstream in the generator — do
+# not silence them here.


### PR DESCRIPTION
## What

Removes the `.*.md` rule from `.gitignore` and replaces it with a loud comment telling future contributors not to re-add it.

## Why

`#212` added:

```
# Generated per-file doc stubs (external doc-orchestrator bot). All documentation
# lives in docs/; these hidden .md files next to source must not be committed.
.*.md
```

Two problems with that:

**1. The inline doc stubs are supposed to be committed.** They're per-file documentation written next to the source they describe, generated by the Flamingo AI Technical Writer. They belong in the repo and in the PR diff, reviewed alongside the code. Ignoring them silently discards the output of every documentation run.

**2. It hard-failed the whole workflow.** `.*.md` also matched the orchestrator's own run status file, so the job died at branch creation, before a single doc was generated:

```text
📝 Creating PR branch early for progressive commits...
Switched to a new branch 'docs/flamingo-ai-technical-writer-1785077147640'
The following paths are ignored by one of your .gitignore files:
.flamingo-ai-technical-writer-status.md
hint: Use -f if you really want to add them.
Error: Process completed with exit code 1.
```

See [run #30206764288](https://github.com/flamingo-stack/openframe-cli/actions/runs/30206764288/job/89806092682).

## Reviewer notes

- No files change state in this PR — the ignored stubs were never committed, so there is nothing to un-ignore retroactively. The next documentation run will bring them in.
- Companion fix in the hub, so the status file can never be blocked by a target repo's ignore rules again: flamingo-stack/multi-platform-hub#953.
- If the inline stubs are ever genuinely unwanted, that's a generator-side setting — not something to silence with an ignore rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository file handling so hidden Markdown documentation files are preserved and tracked.
  * Clarified guidance for maintaining inline documentation files alongside related source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->