### PR TITLE
guard(cluster): scope terraform destroy to a cluster workspace

### DIFF
--- a/internal/cluster/providers/gke/template_guard_test.go
+++ b/internal/cluster/providers/gke/template_guard_test.go
@@ -1,0 +1,53 @@
+package gke
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The GKE root module must never MANAGE the GCP project itself: the project is
+// an input (var.project) the operator already owns, not a resource the CLI
+// creates. If a `resource "google_project"` (or a project-deleting data flow)
+// ever appears in the template, `openframe cluster delete` → terraform destroy
+// would tear down the whole project — every unrelated workload in it included.
+// This test fails loudly the moment the template stops treating the project as
+// read-only.
+func TestTemplate_NeverManagesTheProject(t *testing.T) {
+	src := string(mainTF)
+
+	// No resource that owns the project's lifecycle (create ⇒ destroy).
+	forbidden := []string{
+		`resource "google_project"`,
+		`resource "google_project_iam_policy"`, // authoritative — would overwrite project IAM
+	}
+	for _, decl := range forbidden {
+		assert.NotContainsf(t, src, decl,
+			"GKE template must not declare %s — the project must stay a read-only input, never a managed/destroyable resource", decl)
+	}
+
+	// Belt and braces: no google_project* resource of ANY kind. The only
+	// project-scoped resource we allow is google_project_service (API
+	// enablement), and even that must never disable APIs on destroy.
+	projectResRE := regexp.MustCompile(`resource\s+"(google_project[a-z_]*)"`)
+	for _, m := range projectResRE.FindAllStringSubmatch(src, -1) {
+		assert.Equalf(t, "google_project_service", m[1],
+			"unexpected project-scoped resource %q in the GKE template; only google_project_service is permitted", m[1])
+	}
+
+	// google_project_service must keep disable_on_destroy=false so a cluster
+	// teardown never switches off project APIs other workloads depend on.
+	if assert.Contains(t, src, `resource "google_project_service"`) {
+		assert.Contains(t, src, "disable_on_destroy = false",
+			"google_project_service must set disable_on_destroy=false so destroy never disables project APIs")
+	}
+}
+
+// The project must be consumed strictly as an input variable, proving the
+// template reads the project rather than owning it.
+func TestTemplate_ProjectIsAnInputVariable(t *testing.T) {
+	require.Contains(t, string(mainTF), `variable "project"`,
+		"the project must be a declared input variable, not a resource the template creates")
+}

--- a/internal/cluster/providers/terraform/engine.go
+++ b/internal/cluster/providers/terraform/engine.go
@@ -106,13 +106,38 @@ func (e *Engine) Apply(ctx context.Context, dir string) error {
 }
 
 // Destroy runs terraform destroy in dir, streaming progress like Apply.
+//
+// Guardrail: terraform destroy tears down exactly what the state in `dir`
+// tracks, so `dir` must be a materialized cluster workspace — one holding the
+// CLI-generated main.tf root module. Refusing an empty, wrong, or parent path
+// keeps a destroy strictly inside one cluster's own workspace and never lets
+// terraform be pointed at a directory whose state we did not generate.
 func (e *Engine) Destroy(ctx context.Context, dir string) error {
+	if err := assertClusterWorkspace(dir); err != nil {
+		return err
+	}
 	tf, err := e.newRunner(dir)
 	if err != nil {
 		return err
 	}
 	if err := tf.DestroyJSON(ctx, newProgressWriter(e.verbose)); err != nil {
 		return fmt.Errorf("terraform destroy failed: %w", err)
+	}
+	return nil
+}
+
+// assertClusterWorkspace verifies dir is a generated cluster workspace before
+// a destructive terraform run: it must hold a main.tf root module. This is the
+// scoping check behind Destroy — terraform acts on the state in whatever
+// directory it is handed, so a directory that is not one of our generated
+// workspaces must fail loudly instead of running a destroy.
+func assertClusterWorkspace(dir string) error {
+	info, err := os.Stat(filepath.Join(dir, "main.tf"))
+	if err != nil {
+		return fmt.Errorf("refusing to run terraform destroy in %q: not a cluster workspace (no generated main.tf): %w", dir, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("refusing to run terraform destroy in %q: main.tf is not a regular file", dir)
 	}
 	return nil
 }

--- a/internal/cluster/providers/terraform/engine_test.go
+++ b/internal/cluster/providers/terraform/engine_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -12,6 +14,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// workspaceDir creates a throwaway directory holding a generated main.tf — the
+// minimum that makes it a valid destroy target for the workspace guardrail.
+func workspaceDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# generated"), 0o600))
+	return dir
+}
 
 // fakeRunner records calls and returns canned results.
 type fakeRunner struct {
@@ -83,7 +94,7 @@ func TestEngine_LifecycleCalls(t *testing.T) {
 	changes, err := e.Plan(ctx, t.TempDir())
 	require.NoError(t, err)
 	assert.False(t, changes.HasChanges(), "planChanges=false must summarize to no changes")
-	require.NoError(t, e.Destroy(ctx, "dir"))
+	require.NoError(t, e.Destroy(ctx, workspaceDir(t)))
 
 	outputs, err := e.Outputs(ctx, "dir")
 	require.NoError(t, err)
@@ -92,6 +103,24 @@ func TestEngine_LifecycleCalls(t *testing.T) {
 	assert.Equal(t, "https://example.eks", endpoint)
 
 	assert.Equal(t, []string{"init", "apply", "plan", "destroy", "output"}, f.calls)
+}
+
+// A destroy pointed at anything but a generated cluster workspace must be
+// refused BEFORE terraform runs — this is what confines a destroy to one
+// cluster's own state and keeps it from ever touching an unexpected directory.
+func TestEngine_DestroyRefusesNonWorkspaceDir(t *testing.T) {
+	f := &fakeRunner{}
+	// An empty temp dir has no generated main.tf, so it is not a workspace.
+	err := engineWith(f).Destroy(context.Background(), t.TempDir())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not a cluster workspace")
+	assert.NotContains(t, f.calls, "destroy", "terraform destroy must not run against a non-workspace dir")
+}
+
+func TestEngine_DestroyRunsInWorkspaceDir(t *testing.T) {
+	f := &fakeRunner{}
+	require.NoError(t, engineWith(f).Destroy(context.Background(), workspaceDir(t)))
+	assert.Equal(t, []string{"destroy"}, f.calls)
 }
 
 // action builds a tfjson resource change with the given address and actions.


### PR DESCRIPTION
terraform destroy tears down exactly what the state in its target directory tracks, so add an explicit guardrail: Engine.Destroy now refuses any directory that is not a materialized cluster workspace (one holding the CLI-generated main.tf). This keeps a destroy strictly inside one cluster's own workspace and prevents terraform from ever being pointed at an empty, wrong, or parent path.

Also add template guards proving the GKE root module never MANAGES the GCP project itself: the project stays a read-only input variable, no google_project* resource other than google_project_service appears, and google_project_service keeps disable_on_destroy=false. Without these, a future template change could make `cluster delete` -> terraform destroy tear down the whole project or disable its APIs.