### PR TITLE
fix(gke): actually release PVC disks on delete — target the real namespaces

### DIFF
--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -378,9 +378,10 @@ func (p *Provider) DeleteCluster(ctx context.Context, name string, clusterType m
 	}
 	if recErr == nil {
 		_ = removeFromDefaultKubeconfig(rec)
-		// Surface any PVC-provisioned disks that outlived the destroy so a
-		// "cleaned up" delete never silently leaves billable orphans.
-		p.reportOrphanedDisks(ctx, rec.Project, name)
+		// Sweep any PVC-provisioned disks that outlived the destroy: delete them
+		// when the caller consented to an unattended teardown (--force), else
+		// report them — a "cleaned up" delete must never silently leave orphans.
+		p.sweepOrphanedDisks(ctx, rec.Project, name, force)
 	}
 	return ws.Remove()
 }

--- a/internal/cluster/providers/gke/teardown.go
+++ b/internal/cluster/providers/gke/teardown.go
@@ -14,29 +14,97 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// appNamespaces are the namespaces OpenFrame installs into. They are deleted
-// (argocd first, so its controller stops re-syncing, then openframe) before the
-// infra is destroyed, so the PVCs living in them are removed and the GKE CSI
-// driver deletes their backing Persistent Disks while the cluster is still
-// alive. Order matters — see releaseWorkloadDisks.
-var appNamespaces = []string{"argocd", "openframe"}
+// systemNamespaces and systemNamespacePrefixes are never deleted during
+// teardown. They are the cluster's own control-plane/system namespaces (torn
+// down with the cluster anyway) and — critically — kube-system hosts the GKE PD
+// CSI controller that must keep running to delete the Persistent Disks as their
+// PVCs go away.
+var systemNamespaces = map[string]struct{}{
+	"default":         {},
+	"kube-system":     {},
+	"kube-public":     {},
+	"kube-node-lease": {},
+}
 
-// diskDrainTimeout bounds how long a delete waits for PVC-backed disks to be
-// reclaimed before proceeding to destroy anyway. A live-platform teardown must
-// never block indefinitely; anything not drained in time is surfaced by the
-// post-destroy sweep instead.
-const diskDrainTimeout = 4 * time.Minute
+var systemNamespacePrefixes = []string{"kube-", "gke-", "gmp-"}
 
-// releaseWorkloadDisks deletes the OpenFrame app namespaces on the cluster and
-// waits (bounded) for their PVC-backed PersistentVolumes to drain, so the GKE
-// CSI driver deletes the underlying Persistent Disks BEFORE terraform destroys
-// the node pool. Without this, PVC-provisioned disks — which live outside the
-// terraform state — detach and survive as billable orphans.
+const (
+	// diskDrainTimeout bounds how long a delete waits for PVC-backed disks to be
+	// reclaimed before proceeding to destroy anyway. A live-platform teardown
+	// must never block indefinitely; anything not drained in time is caught by
+	// the post-destroy sweep.
+	diskDrainTimeout = 5 * time.Minute
+	// kubeCallTimeout bounds each individual API call so an unreachable cluster
+	// fails fast instead of hanging the whole delete.
+	kubeCallTimeout = 20 * time.Second
+)
+
+// isSystemNamespace reports whether ns is a cluster/system namespace that
+// teardown must never delete.
+func isSystemNamespace(ns string) bool {
+	if _, ok := systemNamespaces[ns]; ok {
+		return true
+	}
+	for _, p := range systemNamespacePrefixes {
+		if strings.HasPrefix(ns, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// appNamespacesToDelete returns the application namespaces (everything that is
+// not a system namespace), with argocd first. OpenFrame's stateful services
+// (Kafka, MongoDB, Cassandra, Pinot, … in the 'datasources' namespace) hold the
+// PVCs whose backing disks must be released; deleting by discovery rather than a
+// hardcoded list keeps this correct as the platform layout changes. argocd goes
+// first so its controller stops re-syncing before the workloads it manages are
+// deleted, otherwise self-heal could recreate a StatefulSet (and its PVC)
+// mid-teardown.
+func appNamespacesToDelete(all []string) []string {
+	var argocd []string
+	var rest []string
+	for _, ns := range all {
+		if isSystemNamespace(ns) {
+			continue
+		}
+		if ns == "argocd" {
+			argocd = append(argocd, ns)
+		} else {
+			rest = append(rest, ns)
+		}
+	}
+	return append(argocd, rest...)
+}
+
+// countDeletablePVs counts PersistentVolumes whose reclaim policy is Delete.
+// These are the volumes whose backing cloud disk the CSI driver removes once
+// their PVC is gone, so the release step waits for this to reach zero.
+// Retain-policy PVs are excluded on purpose — their disks are meant to survive,
+// and the post-destroy sweep reports (never silently drops) them.
+func countDeletablePVs(pvs []corev1.PersistentVolume) int {
+	var n int
+	for _, pv := range pvs {
+		if pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+			n++
+		}
+	}
+	return n
+}
+
+// releaseWorkloadDisks deletes every application namespace on the cluster and
+// waits (bounded) for the Delete-reclaim PersistentVolumes to drain, so the GKE
+// CSI driver deletes the backing Persistent Disks BEFORE terraform destroys the
+// node pool. Those disks are PVC-provisioned and live OUTSIDE the terraform
+// state, so without this they detach and survive as billable orphans.
 //
-// Entirely best-effort: an unreachable cluster, missing namespaces, RBAC
-// denial, or a drain timeout are all logged and ignored. The infra destroy the
-// user asked for must never be blocked by teardown, and the post-destroy sweep
-// reports anything this misses.
+// Deleting whole namespaces (rather than draining nodes) also avoids the
+// autoscaler racing to reschedule evicted pods onto a fresh node mid-teardown.
+//
+// Entirely best-effort: an unreachable cluster, RBAC denial, or a drain timeout
+// are logged and ignored. The infra destroy the user asked for must never be
+// blocked by teardown, and the post-destroy sweep reports/cleans anything this
+// misses.
 func releaseWorkloadDisks(ctx context.Context, rec tfengine.Record) {
 	restCfg, err := restConfigFor(rec)
 	if err != nil {
@@ -49,95 +117,120 @@ func releaseWorkloadDisks(ctx context.Context, rec tfengine.Record) {
 		return
 	}
 
-	var deleting []string
-	for _, ns := range appNamespaces {
-		// Short per-call context so an unreachable API server fails fast rather
-		// than hanging the whole delete.
-		getCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-		_, err := client.CoreV1().Namespaces().Get(getCtx, ns, metav1.GetOptions{})
-		cancel()
-		if err != nil {
-			continue // absent or unreachable — nothing to release here
-		}
-		delCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-		err = client.CoreV1().Namespaces().Delete(delCtx, ns, metav1.DeleteOptions{})
-		cancel()
-		if err == nil || k8serrors.IsNotFound(err) {
-			deleting = append(deleting, ns)
-		}
+	listCtx, cancel := context.WithTimeout(ctx, kubeCallTimeout)
+	nsList, err := client.CoreV1().Namespaces().List(listCtx, metav1.ListOptions{})
+	cancel()
+	if err != nil {
+		pterm.Debug.Printf("skip pre-destroy disk release (cluster unreachable): %v\n", err)
+		return
 	}
-	if len(deleting) == 0 {
-		return // no OpenFrame workloads on the cluster; nothing to drain
+	names := make([]string, 0, len(nsList.Items))
+	for _, ns := range nsList.Items {
+		names = append(names, ns.Name)
 	}
-	pterm.Info.Printf("Releasing persistent disks (removing %s) before destroy...\n", strings.Join(deleting, ", "))
+	targets := appNamespacesToDelete(names)
+	if len(targets) == 0 {
+		return // no application namespaces — nothing to release
+	}
 
+	pterm.Info.Printf("Releasing persistent disks (removing namespaces: %s) before destroy...\n", strings.Join(targets, ", "))
+	for _, ns := range targets {
+		delCtx, cancel := context.WithTimeout(ctx, kubeCallTimeout)
+		err := client.CoreV1().Namespaces().Delete(delCtx, ns, metav1.DeleteOptions{})
+		cancel()
+		if err != nil && !k8serrors.IsNotFound(err) {
+			pterm.Debug.Printf("namespace %s delete: %v\n", ns, err)
+		}
+	}
+
+	// Wait for Delete-reclaim PVs to disappear — the signal that the CSI driver
+	// has deleted the backing disks. Bounded; on timeout we proceed and let the
+	// sweep handle the remainder.
 	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, diskDrainTimeout, true, func(ctx context.Context) (bool, error) {
-		listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		pvCtx, cancel := context.WithTimeout(ctx, kubeCallTimeout)
 		defer cancel()
-		pvs, err := client.CoreV1().PersistentVolumes().List(listCtx, metav1.ListOptions{})
+		pvs, err := client.CoreV1().PersistentVolumes().List(pvCtx, metav1.ListOptions{})
 		if err != nil {
 			return false, nil // transient — keep polling until the outer timeout
 		}
-		return countClaimedPVs(pvs.Items, deleting) == 0, nil
+		return countDeletablePVs(pvs.Items) == 0, nil
 	})
 }
 
-// countClaimedPVs counts PersistentVolumes still claimed by any of the given
-// namespaces. Once a PVC is deleted its PV is released and (reclaimPolicy
-// Delete) removed, so this reaching zero means the backing disks are gone.
-func countClaimedPVs(pvs []corev1.PersistentVolume, namespaces []string) int {
-	inScope := make(map[string]struct{}, len(namespaces))
-	for _, ns := range namespaces {
-		inScope[ns] = struct{}{}
-	}
-	var n int
-	for _, pv := range pvs {
-		ref := pv.Spec.ClaimRef
-		if ref == nil {
-			continue
-		}
-		if _, ok := inScope[ref.Namespace]; ok {
-			n++
-		}
-	}
-	return n
+// disk is one labeled Persistent Disk found by the post-destroy sweep.
+type disk struct {
+	name string
+	zone string // basename, e.g. "us-central1-a"; empty for a regional disk
 }
 
-// reportOrphanedDisks lists any Persistent Disks still labeled for this cluster
-// after the destroy and prints them with a cleanup command. It is report-only:
-// the CLI never deletes cloud disks directly, so a user is told the truth
-// ("these survived") instead of a false "fully cleaned up". Best-effort — a
-// gcloud hiccup is silently skipped.
-func (p *Provider) reportOrphanedDisks(ctx context.Context, project, name string) {
+// sweepOrphanedDisks finds Persistent Disks still labeled for this cluster after
+// the destroy. Post-destroy they are unambiguous orphans of a cluster that no
+// longer exists. When the caller consented to an unattended teardown (force),
+// it deletes them so the cluster leaves zero billable leftovers; otherwise it
+// reports them with the exact cleanup command and never deletes cloud data
+// without consent. Best-effort throughout.
+func (p *Provider) sweepOrphanedDisks(ctx context.Context, project, name string, force bool) {
 	if project == "" {
 		return
 	}
 	res, err := p.executor.Execute(ctx, "gcloud", "compute", "disks", "list",
 		"--project", project,
 		"--filter", "labels.goog-k8s-cluster-name="+name,
-		"--format=value(name,location,sizeGb)")
+		"--format=value(name,zone.basename())")
 	if err != nil || res == nil {
 		return
 	}
-	disks := parseDiskList(res.Stdout)
+	disks := parseDisks(res.Stdout)
 	if len(disks) == 0 {
 		return
 	}
-	pterm.Warning.Printf("%d Persistent Disk(s) labeled for cluster %q survived the destroy (PVC-provisioned, outside terraform state):\n", len(disks), name)
-	for _, d := range disks {
-		pterm.Warning.Printf("  - %s\n", d)
+
+	if !force {
+		pterm.Warning.Printf("%d Persistent Disk(s) labeled for cluster %q survived the destroy (PVC-provisioned, outside terraform state):\n", len(disks), name)
+		for _, d := range disks {
+			pterm.Warning.Printf("  - %s\n", d.name)
+		}
+		pterm.Warning.Printf("They are orphans of the now-deleted cluster. Remove them with:\n"+
+			"  gcloud compute disks list --project %s --filter=\"labels.goog-k8s-cluster-name=%s\"\n"+
+			"  (or re-run delete with --force to have them cleaned up automatically)\n", project, name)
+		return
 	}
-	pterm.Warning.Printf("Review and remove them with:\n  gcloud compute disks list --project %s --filter=\"labels.goog-k8s-cluster-name=%s\"\n", project, name)
+
+	pterm.Info.Printf("Cleaning up %d orphaned Persistent Disk(s) from cluster %q...\n", len(disks), name)
+	var failed []string
+	for _, d := range disks {
+		if d.zone == "" {
+			failed = append(failed, d.name+" (regional — delete manually)")
+			continue
+		}
+		if _, err := p.executor.Execute(ctx, "gcloud", "compute", "disks", "delete", d.name,
+			"--zone", d.zone, "--project", project, "--quiet"); err != nil {
+			failed = append(failed, d.name)
+		}
+	}
+	if len(failed) > 0 {
+		pterm.Warning.Printf("Could not delete %d disk(s): %s\n  Remove manually: gcloud compute disks delete <name> --zone <zone> --project %s\n",
+			len(failed), strings.Join(failed, ", "), project)
+		return
+	}
+	pterm.Success.Printf("Removed %d orphaned Persistent Disk(s)\n", len(disks))
 }
 
-// parseDiskList turns `gcloud compute disks list --format=value(...)` output
-// into one entry per non-empty line.
-func parseDiskList(out string) []string {
-	var disks []string
+// parseDisks turns `gcloud compute disks list
+// --format=value(name,zone.basename())` output into disks — one per non-empty
+// line, fields separated by whitespace (name, then optional zone).
+func parseDisks(out string) []disk {
+	var disks []disk
 	for _, line := range strings.Split(out, "\n") {
-		if s := strings.TrimSpace(line); s != "" {
-			disks = append(disks, s)
+		if strings.TrimSpace(line) == "" {
+			continue
 		}
+		fields := strings.Fields(line)
+		d := disk{name: fields[0]}
+		if len(fields) > 1 {
+			d.zone = fields[1]
+		}
+		disks = append(disks, d)
 	}
 	return disks
 }

--- a/internal/cluster/providers/gke/teardown_test.go
+++ b/internal/cluster/providers/gke/teardown_test.go
@@ -1,43 +1,114 @@
 package gke
 
 import (
+	"context"
 	"testing"
 
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func pv(ns string) corev1.PersistentVolume {
-	p := corev1.PersistentVolume{}
-	if ns != "" {
-		p.Spec.ClaimRef = &corev1.ObjectReference{Namespace: ns}
+func TestAppNamespacesToDelete(t *testing.T) {
+	all := []string{
+		"kube-system", "kube-public", "kube-node-lease", "default", // system — skipped
+		"gke-managed-system", "gmp-system", // GKE-managed — skipped
+		"tenant", "datasources", "platform", "argocd", // app — kept
 	}
-	return p
+	got := appNamespacesToDelete(all)
+
+	// argocd must come first so its controller stops re-syncing before its
+	// managed workloads (and their PVCs) are deleted.
+	if len(got) == 0 || got[0] != "argocd" {
+		t.Fatalf("argocd must be deleted first, got %v", got)
+	}
+	want := map[string]bool{"argocd": true, "datasources": true, "platform": true, "tenant": true}
+	if len(got) != len(want) {
+		t.Fatalf("expected exactly the app namespaces, got %v", got)
+	}
+	for _, ns := range got {
+		if !want[ns] {
+			t.Fatalf("system namespace %q must never be deleted; got %v", ns, got)
+		}
+	}
 }
 
-func TestCountClaimedPVs(t *testing.T) {
+func TestIsSystemNamespace(t *testing.T) {
+	for _, ns := range []string{"kube-system", "kube-public", "default", "gke-managed-cim", "gmp-public"} {
+		if !isSystemNamespace(ns) {
+			t.Errorf("%q must be treated as a system namespace", ns)
+		}
+	}
+	for _, ns := range []string{"datasources", "tenant", "argocd", "platform"} {
+		if isSystemNamespace(ns) {
+			t.Errorf("%q is an app namespace, not system", ns)
+		}
+	}
+}
+
+func TestCountDeletablePVs(t *testing.T) {
 	pvs := []corev1.PersistentVolume{
-		pv("openframe"),   // in scope
-		pv("openframe"),   // in scope
-		pv("argocd"),      // in scope
-		pv("kube-system"), // out of scope — must not be counted
-		pv(""),            // unbound (no claimRef) — must not be counted
+		{Spec: corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete}},
+		{Spec: corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete}},
+		{Spec: corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain}}, // not counted
 	}
-	if got := countClaimedPVs(pvs, []string{"argocd", "openframe"}); got != 3 {
-		t.Fatalf("countClaimedPVs = %d, want 3 (only app-namespace claims)", got)
-	}
-	if got := countClaimedPVs(nil, []string{"openframe"}); got != 0 {
-		t.Fatalf("countClaimedPVs(nil) = %d, want 0", got)
+	if got := countDeletablePVs(pvs); got != 2 {
+		t.Fatalf("countDeletablePVs = %d, want 2 (Retain excluded)", got)
 	}
 }
 
-func TestParseDiskList(t *testing.T) {
-	// gcloud value() output: one disk per line, blank lines when there are none.
-	out := "pvc-abc\tus-central1-a\t20\npvc-def\tus-central1-b\t8\n\n"
-	got := parseDiskList(out)
-	if len(got) != 2 {
-		t.Fatalf("parseDiskList returned %d entries, want 2: %v", len(got), got)
+func TestParseDisks(t *testing.T) {
+	out := "pvc-abc\tus-central1-a\npvc-def\tus-central1-b\nregional-disk\n\n"
+	got := parseDisks(out)
+	if len(got) != 3 {
+		t.Fatalf("parseDisks returned %d, want 3: %+v", len(got), got)
 	}
-	if parseDiskList("") != nil || len(parseDiskList("\n \n")) != 0 {
-		t.Fatal("empty/whitespace gcloud output must yield no disks")
+	if got[0].name != "pvc-abc" || got[0].zone != "us-central1-a" {
+		t.Fatalf("first disk = %+v", got[0])
 	}
+	if got[2].name != "regional-disk" || got[2].zone != "" {
+		t.Fatalf("zoneless disk must parse with empty zone, got %+v", got[2])
+	}
+	if len(parseDisks("")) != 0 {
+		t.Fatal("empty output must yield no disks")
+	}
+}
+
+// The post-destroy sweep must only delete cloud disks when the caller consented
+// to an unattended teardown (--force); otherwise it reports and touches nothing.
+func TestSweepOrphanedDisks_ConsentGating(t *testing.T) {
+	listResp := &executor.CommandResult{ExitCode: 0, Stdout: "pvc-abc\tus-central1-a\n"}
+
+	t.Run("no force: reports, never deletes", func(t *testing.T) {
+		p, _, _ := newTestProvider(t, nil)
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud compute disks list", listResp)
+		p.executor = mock
+
+		p.sweepOrphanedDisks(context.Background(), "proj", "demo", false)
+		if mock.WasCommandExecuted("gcloud compute disks delete") {
+			t.Fatal("without --force the sweep must NOT delete disks")
+		}
+	})
+
+	t.Run("force: deletes the labeled orphan", func(t *testing.T) {
+		p, _, _ := newTestProvider(t, nil)
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud compute disks list", listResp)
+		p.executor = mock
+
+		p.sweepOrphanedDisks(context.Background(), "proj", "demo", true)
+		if !mock.WasCommandExecuted("gcloud compute disks delete pvc-abc --zone us-central1-a") {
+			t.Fatalf("with --force the sweep must delete the orphan; ran: %v", mock.GetExecutedCommands())
+		}
+	})
+
+	t.Run("empty project is a no-op", func(t *testing.T) {
+		p, _, _ := newTestProvider(t, nil)
+		mock := executor.NewMockCommandExecutor()
+		p.executor = mock
+		p.sweepOrphanedDisks(context.Background(), "", "demo", true)
+		if mock.GetCommandCount() != 0 {
+			t.Fatal("no project → no gcloud calls")
+		}
+	})
 }


### PR DESCRIPTION
The prior teardown deleted only 'argocd' (no PVCs) and a non-existent 'openframe' namespace, so the disks it was meant to free never drained: OpenFrame's stateful services (Kafka, Mongo, Cassandra, Pinot, Fleet MySQL) live in the 'datasources' namespace, which the teardown never touched. The honest orphan report landed, but 14 disks still survived every delete.

Release the disks properly:
- delete app namespaces by DISCOVERY (every non-system namespace, argocd first so its controller stops re-syncing), not a hardcoded guess — stays correct as the platform layout changes and never touches kube-system, which hosts the CSI controller that does the disk deletion;
- wait for Delete-reclaim PVs to drain (Retain PVs excluded — their disks are meant to survive) so the CSI driver removes the disks before the node pool dies. Deleting namespaces (not draining nodes) also avoids the autoscaler racing to reschedule evicted pods.

Post-destroy sweep now completes the job: when the caller consented to an unattended teardown (--force) it deletes the labeled orphans (unambiguous leftovers of a now-deleted cluster); otherwise it reports them. Retain intent stays safe on the default interactive path (report-only).