### PR TITLE
fix(cluster): stop showing k3d-specific details for GKE clusters

### DIFF
--- a/cmd/cluster/delete.go
+++ b/cmd/cluster/delete.go
@@ -121,6 +121,6 @@ func runDeleteCluster(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show friendly success message
-	operationsUI.ShowOperationSuccess("delete", clusterName)
+	operationsUI.ShowOperationSuccess("delete", clusterName, clusterType)
 	return nil
 }

--- a/internal/cluster/discovery/auth.go
+++ b/internal/cluster/discovery/auth.go
@@ -66,8 +66,21 @@ func (f *AuthFlow) Ensure(ctx context.Context, requireADC bool) error {
 	case NotAuthenticated:
 		if err := f.login(ctx, "Google Cloud login required. Log in now (opens a browser)?",
 			[]string{"auth", "login"},
-			func() bool { return d.AuthStatus(ctx) == Authenticated },
+			func() bool { return f.hasFreshLogin(ctx) },
 			"gcloud is not authenticated — run 'gcloud auth login'"); err != nil {
+			return err
+		}
+	}
+
+	// A listed ACTIVE account can still have an EXPIRED token — `gcloud auth
+	// list` reports it as active regardless. Force a refresh here so an expired
+	// primary login is caught up front with a clear hint, instead of surfacing
+	// later as a raw gcloud error (after the ADC step, or mid-terraform).
+	if !f.hasFreshLogin(ctx) {
+		if err := f.login(ctx, "Google Cloud login has expired. Log in again now (opens a browser)?",
+			[]string{"auth", "login"},
+			func() bool { return f.hasFreshLogin(ctx) },
+			"gcloud login has expired — run 'gcloud auth login'"); err != nil {
 			return err
 		}
 	}
@@ -87,6 +100,15 @@ func (f *AuthFlow) Ensure(ctx context.Context, requireADC bool) error {
 // hasADC probes Application Default Credentials without prompting.
 func (f *AuthFlow) hasADC(ctx context.Context) bool {
 	result, err := f.exec.Execute(ctx, "gcloud", "auth", "application-default", "print-access-token")
+	return err == nil && result != nil && strings.TrimSpace(result.Stdout) != ""
+}
+
+// hasFreshLogin reports whether the primary gcloud login can actually mint a
+// token — present AND not expired. `gcloud auth print-access-token` forces a
+// refresh and fails on an expired login, unlike `gcloud auth list` (which
+// reports an expired account as still ACTIVE).
+func (f *AuthFlow) hasFreshLogin(ctx context.Context) bool {
+	result, err := f.exec.Execute(ctx, "gcloud", "auth", "print-access-token", "--quiet")
 	return err == nil && result != nil && strings.TrimSpace(result.Stdout) != ""
 }
 

--- a/internal/cluster/discovery/auth_test.go
+++ b/internal/cluster/discovery/auth_test.go
@@ -37,7 +37,10 @@ func newAuthHarness(t *testing.T, interactive bool) *authFlowHarness {
 			if strings.Contains(joined, "application-default") {
 				h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
 			} else {
+				// A fresh `auth login` makes the account listed AND able to mint a
+				// token (the freshness probe).
 				h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+				h.mock.SetResponse("gcloud auth print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
 			}
 			return nil
 		})
@@ -46,16 +49,27 @@ func newAuthHarness(t *testing.T, interactive bool) *authFlowHarness {
 
 func (h *authFlowHarness) loggedOut() {
 	h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: ""})
+	h.mock.SetResponse("gcloud auth print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "reauth required"})
 	h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "no credentials"})
 }
 
 func (h *authFlowHarness) loggedIn(withADC bool) {
 	h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	h.mock.SetResponse("gcloud auth print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
 	if withADC {
 		h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
 	} else {
 		h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "no credentials"})
 	}
+}
+
+// primaryExpired models the M6 case: the account is listed ACTIVE but its token
+// is expired, so `gcloud auth list` still shows it while `print-access-token`
+// fails.
+func (h *authFlowHarness) primaryExpired() {
+	h.mock.SetResponse("gcloud auth list", &executor.CommandResult{ExitCode: 0, Stdout: "me@example.com\n"})
+	h.mock.SetResponse("gcloud auth print-access-token", &executor.CommandResult{ExitCode: 1, Stderr: "reauth required"})
+	h.mock.SetResponse("application-default print-access-token", &executor.CommandResult{ExitCode: 0, Stdout: "ya29.token\n"})
 }
 
 func TestAuthFlow_AlreadyAuthenticatedIsSilent(t *testing.T) {
@@ -89,6 +103,28 @@ func TestAuthFlow_ADCOnlyWhenCLICredsPresent(t *testing.T) {
 
 	require.NoError(t, h.flow.Ensure(context.Background(), true))
 	assert.Equal(t, []string{"auth application-default login"}, h.logins)
+}
+
+// M6: an expired primary login (listed ACTIVE but no mintable token) must be
+// caught and re-logged-in BEFORE the ADC step, not surface later as a raw error.
+func TestAuthFlow_ExpiredPrimaryLoginReLogsIn(t *testing.T) {
+	h := newAuthHarness(t, true)
+	h.primaryExpired()
+
+	require.NoError(t, h.flow.Ensure(context.Background(), true))
+	assert.Equal(t, []string{"auth login"}, h.logins,
+		"expired primary login must trigger re-login, and before any ADC step")
+}
+
+func TestAuthFlow_ExpiredPrimaryNonInteractiveErrors(t *testing.T) {
+	h := newAuthHarness(t, false)
+	h.primaryExpired()
+
+	err := h.flow.Ensure(context.Background(), true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired", "the error must name the expired login, with the gcloud auth login hint")
+	assert.Contains(t, err.Error(), "gcloud auth login")
+	assert.Empty(t, h.logins)
 }
 
 func TestAuthFlow_NonInteractiveNeverPrompts(t *testing.T) {

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -216,7 +216,7 @@ func (s *ClusterService) CreateCluster(ctx context.Context, config models.Cluste
 	}
 
 	// Show next steps
-	s.showNextSteps(config.Name)
+	s.showNextSteps(config.Name, config.Type)
 
 	return restConfig, nil
 }
@@ -728,8 +728,11 @@ func (s *ClusterService) isK3dWorkerNode(nodeName, clusterName string) bool {
 // when the port is taken (see providers/k3d/ports.go). So on any machine with
 // a second cluster the box pointed the user at a different cluster's API
 // server. The kubeconfig records the port that was actually bound.
-func (s *ClusterService) apiServerEndpoint(ctx context.Context, name string) string {
-	cfg, err := s.manager.GetRestConfig(ctx, name)
+func (s *ClusterService) apiServerEndpoint(name string) string {
+	// Resolve via the cluster-type-aware path (cloud registry first, then k3d),
+	// not the k3d manager directly — otherwise a GKE cluster's endpoint always
+	// read back empty and the box printed "(unknown — kubeconfig not readable)".
+	cfg, err := s.GetRestConfig(name)
 	if err != nil || cfg == nil {
 		return ""
 	}
@@ -754,16 +757,20 @@ func (s *ClusterService) displayClusterCreationSummary(info models.ClusterInfo) 
 		"NAME:     %s\n"+
 			"TYPE:     %s\n"+
 			"STATUS:   %s\n"+
-			"NODES:    %d\n"+
-			"NETWORK:  k3d-%s\n"+
-			"%s",
+			"NODES:    %d",
 		pterm.Bold.Sprint(info.Name),
 		strings.ToUpper(string(info.Type)),
 		pterm.Green("Ready"),
 		info.NodeCount,
-		info.Name,
-		apiServerLine(s.apiServerEndpoint(context.Background(), info.Name)),
 	)
+	// The k3d-<name> Docker network is k3d-specific; a cloud cluster shows its
+	// region instead so the box never invents a k3d network for GKE/EKS.
+	if info.Type == models.ClusterTypeK3d {
+		boxContent += fmt.Sprintf("\nNETWORK:  k3d-%s", info.Name)
+	} else if info.Region != "" {
+		boxContent += fmt.Sprintf("\nREGION:   %s", info.Region)
+	}
+	boxContent += "\n" + apiServerLine(s.apiServerEndpoint(info.Name))
 
 	pterm.DefaultBox.
 		WithTitle(" ✅ Cluster Created ").
@@ -772,7 +779,7 @@ func (s *ClusterService) displayClusterCreationSummary(info models.ClusterInfo) 
 }
 
 // showNextSteps displays clean next steps after cluster creation
-func (s *ClusterService) showNextSteps(clusterName string) {
+func (s *ClusterService) showNextSteps(clusterName string, clusterType models.ClusterType) {
 	// Skip showing next steps if UI is suppressed (e.g., during bootstrap)
 	if s.suppressUI {
 		return
@@ -780,7 +787,14 @@ func (s *ClusterService) showNextSteps(clusterName string) {
 
 	pterm.DefaultBasicText.Println()
 	pterm.Info.Printf("🚀 Next Steps:\n")
-	pterm.DefaultBasicText.Printf("  1. Bootstrap platform:   openframe bootstrap\n")
+	// k3d bootstraps the whole platform in one shot; a cloud cluster already
+	// exists, so the next step is installing the platform onto it (per the GKE
+	// guide) — 'openframe bootstrap' would try to build a local cluster.
+	if clusterType == models.ClusterTypeK3d {
+		pterm.DefaultBasicText.Printf("  1. Bootstrap platform:   openframe bootstrap\n")
+	} else {
+		pterm.DefaultBasicText.Printf("  1. Install the platform: openframe app install\n")
+	}
 	pterm.DefaultBasicText.Printf("  2. Check cluster nodes:  kubectl get nodes\n")
 	pterm.DefaultBasicText.Printf("  3. View cluster status:  openframe cluster status %s\n", clusterName)
 	pterm.DefaultBasicText.Printf("  4. View running pods:    kubectl get pods -A\n")
@@ -869,23 +883,23 @@ func (s *ClusterService) displayDetailedClusterStatus(status models.ClusterInfo,
 		}
 	}
 
-	endpoint := s.apiServerEndpoint(context.Background(), status.Name)
+	endpoint := s.apiServerEndpoint(status.Name)
 	boxContent := fmt.Sprintf(
 		"NAME:     %s\n"+
 			"TYPE:     %s\n"+
 			"STATUS:   %s\n"+
-			"NODES:    %d\n"+
-			"NETWORK:  k3d-%s\n"+
-			"%s\n"+
-			"AGE:      %s",
+			"NODES:    %d",
 		pterm.Bold.Sprint(status.Name),
 		strings.ToUpper(string(status.Type)),
 		statusDisplay,
 		status.NodeCount,
-		status.Name,
-		apiServerLine(endpoint),
-		ageStr,
 	)
+	if status.Type == models.ClusterTypeK3d {
+		boxContent += fmt.Sprintf("\nNETWORK:  k3d-%s", status.Name)
+	} else if status.Region != "" {
+		boxContent += fmt.Sprintf("\nREGION:   %s", status.Region)
+	}
+	boxContent += fmt.Sprintf("\n%s\nAGE:      %s", apiServerLine(endpoint), ageStr)
 
 	pterm.DefaultBox.
 		WithTitle(" 📊 Cluster Status ").
@@ -895,7 +909,11 @@ func (s *ClusterService) displayDetailedClusterStatus(status models.ClusterInfo,
 	// Network information
 	pterm.DefaultBasicText.Println()
 	pterm.Info.Printf("🌐 Network Information:\n")
-	pterm.DefaultBasicText.Printf("  Network:    k3d-%s\n", status.Name)
+	if status.Type == models.ClusterTypeK3d {
+		pterm.DefaultBasicText.Printf("  Network:    k3d-%s\n", status.Name)
+	} else if status.Region != "" {
+		pterm.DefaultBasicText.Printf("  Region:     %s\n", status.Region)
+	}
 	if endpoint != "" {
 		pterm.DefaultBasicText.Printf("  API Server: %s\n", endpoint)
 	}

--- a/internal/cluster/ui/operations.go
+++ b/internal/cluster/ui/operations.go
@@ -271,8 +271,10 @@ func (ui *OperationsUI) ShowCleanupSummary(clusterName string, result models.Cle
 	}
 }
 
-// ShowOperationSuccess displays a friendly success message
-func (ui *OperationsUI) ShowOperationSuccess(operation, clusterName string) {
+// ShowOperationSuccess displays a friendly success message. clusterType lets
+// the box tell the truth per backend — a GKE delete must not claim "TYPE: k3d"
+// or "Docker containers cleaned up".
+func (ui *OperationsUI) ShowOperationSuccess(operation, clusterName string, clusterType models.ClusterType) {
 	switch strings.ToLower(operation) {
 	case "delete":
 		pterm.Success.Printf("Cluster '%s' deleted successfully\n", pterm.Cyan(clusterName))
@@ -283,12 +285,10 @@ func (ui *OperationsUI) ShowOperationSuccess(operation, clusterName string) {
 			"NAME:         %s\n"+
 				"TYPE:         %s\n"+
 				"STATUS:       %s\n"+
-				"NETWORK:      %s\n"+
 				"RESOURCES:    %s",
 			pterm.Bold.Sprint(clusterName),
-			"k3d",
+			strings.ToUpper(string(clusterType)),
 			pterm.Red("Deleted"),
-			pterm.Gray("Removed"),
 			pterm.Gray("Cleaned up"),
 		)
 
@@ -297,13 +297,18 @@ func (ui *OperationsUI) ShowOperationSuccess(operation, clusterName string) {
 			WithTitleTopCenter().
 			Println(boxContent)
 
-		// Show deletion summary
+		// Show deletion summary — the mechanics differ per backend.
 		pterm.DefaultBasicText.Println()
 		pterm.Info.Printf("Deletion Summary:\n")
-		pterm.DefaultBasicText.Printf("  Cluster and nodes removed\n")
-		pterm.DefaultBasicText.Printf("  Docker containers cleaned up\n")
-		pterm.DefaultBasicText.Printf("  Network configuration removed\n")
-		pterm.DefaultBasicText.Printf("  Kubeconfig entries cleaned\n")
+		if clusterType == models.ClusterTypeK3d {
+			pterm.DefaultBasicText.Printf("  Cluster and nodes removed\n")
+			pterm.DefaultBasicText.Printf("  Docker containers cleaned up\n")
+			pterm.DefaultBasicText.Printf("  Network configuration removed\n")
+			pterm.DefaultBasicText.Printf("  Kubeconfig entries cleaned\n")
+		} else {
+			pterm.DefaultBasicText.Printf("  Cloud infrastructure destroyed (terraform)\n")
+			pterm.DefaultBasicText.Printf("  Kubeconfig entries cleaned\n")
+		}
 
 	default:
 		pterm.Success.Printf("Operation '%s' completed for cluster '%s'\n", operation, pterm.Cyan(clusterName))

--- a/internal/cluster/ui/operations_test.go
+++ b/internal/cluster/ui/operations_test.go
@@ -119,14 +119,24 @@ func TestOperationsUI_ShowOperationSuccess(t *testing.T) {
 	// "cleanup" is deliberately absent: cleanup reports through
 	// ShowCleanupSummary, which prints the counts the run actually produced
 	// rather than a fixed list of accomplishments.
-	t.Run("shows delete success without panicking", func(t *testing.T) {
+	t.Run("shows k3d delete success without panicking", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("ShowOperationSuccess panicked: %v", r)
 			}
 		}()
 
-		ui.ShowOperationSuccess("delete", "test-cluster")
+		ui.ShowOperationSuccess("delete", "test-cluster", models.ClusterTypeK3d)
+	})
+
+	t.Run("shows gke delete success without panicking", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("ShowOperationSuccess panicked: %v", r)
+			}
+		}()
+
+		ui.ShowOperationSuccess("delete", "test-cluster", models.ClusterTypeGKE)
 	})
 
 	t.Run("shows generic success without panicking", func(t *testing.T) {
@@ -136,7 +146,7 @@ func TestOperationsUI_ShowOperationSuccess(t *testing.T) {
 			}
 		}()
 
-		ui.ShowOperationSuccess("unknown", "test-cluster")
+		ui.ShowOperationSuccess("unknown", "test-cluster", models.ClusterTypeK3d)
 	})
 }
 


### PR DESCRIPTION
    The create/delete/status boxes reused the k3d template verbatim, so a GKE
    cluster's delete box claimed 'TYPE: k3d' and 'Docker containers cleaned
    up', the create box printed 'NETWORK: k3d-<name>' and 'API: (unknown —
    kubeconfig not readable)', and next-steps suggested 'openframe bootstrap'
    (which builds a local cluster) instead of 'app install'.

    Make the display type-aware:
    - delete box shows the real TYPE and backend-appropriate summary lines;
    - create/status boxes show REGION for cloud clusters (k3d-<name> only for
      k3d) and resolve the API endpoint via the type-aware GetRestConfig (the
      old path used the k3d manager, which always read empty for GKE);
    - next-steps suggests 'openframe app install' for cloud, 'bootstrap' for k3d