### PR TITLE
fix(gke): zonal clusters by default so --nodes N means N, not N-per-zone

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -49,9 +49,12 @@ Examples:
 			}
 			// create runs its own type-aware gate after the cluster type is known
 			// (a cloud cluster must not demand Docker/k3d); use only flips local
-			// kubeconfig/gcloud state and needs no tools at all. The other
-			// subcommands are k3d-scoped, so the k3d gate stays here.
-			if cmd.Name() == "create" || cmd.Name() == "use" {
+			// kubeconfig/gcloud state and needs no tools at all. status and list
+			// are cross-provider read-only views: they must work against a cloud
+			// cluster with Docker stopped, so they skip the k3d gate and degrade
+			// gracefully instead (k3d enumeration is best-effort in the service).
+			switch cmd.Name() {
+			case "create", "use", "status", "list":
 				return nil
 			}
 			return prerequisites.CheckPrerequisites()

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -290,6 +290,7 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 				MinNodes:      cf.MinNodes,
 				MaxNodes:      cf.MaxNodes,
 				Spot:          cf.Spot,
+				HA:            cf.HA,
 				BackendConfig: cf.BackendConfig,
 			}
 		}

--- a/internal/chart/providers/helm/argocd_wait.go
+++ b/internal/chart/providers/helm/argocd_wait.go
@@ -163,6 +163,24 @@ func (h *HelmManager) ensureArgoCDNamespace(ctx context.Context, clusterName str
 	})
 }
 
+// apiDialAddress turns a rest.Config Host into a dialable host:port. It strips
+// the scheme and, when the endpoint carries no explicit port, defaults to the
+// HTTPS port. Managed control planes (GKE/EKS) expose a bare host with no port
+// (e.g. https://34.9.1.2); a TCP dial requires host:port, so without this the
+// dial fails with "missing port in address" on every poll and the wait always
+// times out even though the API is up. k3d endpoints already include :6550 and
+// pass through unchanged. Returns "" when no address can be determined.
+func apiDialAddress(host string) string {
+	addr := strings.TrimPrefix(strings.TrimPrefix(host, "https://"), "http://")
+	if addr == "" {
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(addr, "443")
+	}
+	return addr
+}
+
 // waitForAPIPort waits for the Kubernetes API port to be open before making API calls
 // This prevents flooding a dead port with requests on Windows/WSL2 where the port
 // might not be immediately available after k3d reports success
@@ -172,7 +190,7 @@ func (h *HelmManager) waitForAPIPort(ctx context.Context, timeout time.Duration)
 	}
 
 	// Extract host:port from kubeConfig.Host
-	apiAddress := strings.TrimPrefix(strings.TrimPrefix(h.kubeConfig.Host, "https://"), "http://")
+	apiAddress := apiDialAddress(h.kubeConfig.Host)
 	if apiAddress == "" {
 		return nil // Skip if we can't determine the address
 	}

--- a/internal/chart/providers/helm/argocd_wait_test.go
+++ b/internal/chart/providers/helm/argocd_wait_test.go
@@ -1,0 +1,29 @@
+package helm
+
+import "testing"
+
+// apiDialAddress must produce a dialable host:port for every endpoint shape.
+// The regression it guards: GKE/EKS endpoints are a bare host with no port, so
+// a naive scheme-strip left the dialer with "missing port in address" and the
+// API-port wait always timed out even though ArgoCD was already healthy.
+func TestAPIDialAddress(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"gke bare host defaults to 443", "https://34.9.1.2", "34.9.1.2:443"},
+		{"eks dns host defaults to 443", "https://ABCD.gr7.us-east-1.eks.amazonaws.com", "ABCD.gr7.us-east-1.eks.amazonaws.com:443"},
+		{"k3d endpoint keeps its explicit port", "https://127.0.0.1:6550", "127.0.0.1:6550"},
+		{"http scheme is stripped too", "http://10.0.0.1", "10.0.0.1:443"},
+		{"host already host:port is untouched", "10.0.0.1:6443", "10.0.0.1:6443"},
+		{"empty host yields empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := apiDialAddress(tc.host); got != tc.want {
+				t.Fatalf("apiDialAddress(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cluster/models/cluster.go
+++ b/internal/cluster/models/cluster.go
@@ -32,6 +32,13 @@ type CloudConfig struct {
 	MinNodes    int    `json:"min_nodes,omitempty"`
 	MaxNodes    int    `json:"max_nodes,omitempty"`
 	Spot        bool   `json:"spot,omitempty"`
+	// HA requests a regional (multi-zone) control plane and node pool. Default
+	// (false) is a single-zone cluster, so the node count is exact — N means N,
+	// not N-per-zone. GKE only.
+	HA bool `json:"ha,omitempty"`
+	// Zone is the single zone a zonal (non-HA) GKE cluster lives in, e.g.
+	// "us-central1-a". Derived from Region by the provider; empty for HA.
+	Zone string `json:"zone,omitempty"`
 	// BackendConfig is an optional remote-state location
 	// (s3://bucket/prefix for EKS, gcs://bucket/prefix for GKE);
 	// empty means local state in the cluster workspace.

--- a/internal/cluster/models/flags.go
+++ b/internal/cluster/models/flags.go
@@ -28,6 +28,7 @@ type CreateFlags struct {
 	MinNodes      int
 	MaxNodes      int
 	Spot          bool
+	HA            bool
 	BackendConfig string
 }
 
@@ -80,6 +81,7 @@ func AddCreateFlags(cmd *cobra.Command, flags *CreateFlags) {
 	cmd.Flags().IntVar(&flags.MinNodes, "min-nodes", 0, "Node group minimum size (cloud only)")
 	cmd.Flags().IntVar(&flags.MaxNodes, "max-nodes", 0, "Node group maximum size (cloud only)")
 	cmd.Flags().BoolVar(&flags.Spot, "spot", false, "Use spot capacity for nodes (cloud only)")
+	cmd.Flags().BoolVar(&flags.HA, "ha", false, "Regional (multi-zone) control plane and nodes for HA (gke only); default is a single-zone cluster where --nodes is the exact node count")
 	cmd.Flags().StringVar(&flags.BackendConfig, "backend-config", "", "Remote terraform state: s3://bucket/prefix (eks) or gcs://bucket/prefix (gke); default is local state")
 }
 
@@ -179,8 +181,8 @@ func ValidateCreateFlags(flags *CreateFlags) error {
 		case flags.BackendConfig != "":
 			return fmt.Errorf("--backend-config only applies to cloud cluster types (eks, gke)")
 		case flags.Region != "" || flags.Profile != "" || flags.Project != "" ||
-			flags.MachineType != "" || flags.MinNodes != 0 || flags.MaxNodes != 0 || flags.Spot:
-			return fmt.Errorf("--region/--profile/--project/--machine-type/--min-nodes/--max-nodes/--spot only apply to cloud cluster types (eks, gke)")
+			flags.MachineType != "" || flags.MinNodes != 0 || flags.MaxNodes != 0 || flags.Spot || flags.HA:
+			return fmt.Errorf("--region/--profile/--project/--machine-type/--min-nodes/--max-nodes/--spot/--ha only apply to cloud cluster types (eks, gke)")
 		}
 	}
 	if flags.MinNodes < 0 || flags.MaxNodes < 0 {

--- a/internal/cluster/providers/gke/orphan_test.go
+++ b/internal/cluster/providers/gke/orphan_test.go
@@ -1,0 +1,32 @@
+package gke
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOrphanFromInterruptedCreate(t *testing.T) {
+	t.Run("names the orphaned resource on a 409", func(t *testing.T) {
+		// Shape of a real terraform google-provider 409 during a resume.
+		err := errors.New("Error: Error creating Network: googleapi: Error 409: The resource " +
+			"'projects/tenant-y0/global/networks/test-resume-vpc' already exists, alreadyExists")
+		hint, ok := orphanFromInterruptedCreate(err, "/ws/test/terraform")
+		if !ok {
+			t.Fatal("expected a 409 AlreadyExists to be detected as an interrupted-create orphan")
+		}
+		if !strings.Contains(hint, "projects/tenant-y0/global/networks/test-resume-vpc") {
+			t.Fatalf("hint must name the exact orphaned resource, got:\n%s", hint)
+		}
+		if !strings.Contains(hint, "/ws/test/terraform") {
+			t.Fatalf("hint must reference the workspace terraform dir for import, got:\n%s", hint)
+		}
+	})
+
+	t.Run("ignores unrelated apply errors", func(t *testing.T) {
+		err := errors.New("Error: quota 'CPUS' exceeded, limit 24.0 in region us-central1")
+		if _, ok := orphanFromInterruptedCreate(err, "/ws/test/terraform"); ok {
+			t.Fatal("a non-409 error must not be reported as an orphan")
+		}
+	})
+}

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -319,14 +319,24 @@ func (p *Provider) DeleteCluster(ctx context.Context, name string, clusterType m
 		return models.NewClusterNotFoundError(name)
 	}
 	// Read the record BEFORE destroy: the endpoint in it is what proves the
-	// kubeconfig entry is ours to remove afterwards.
+	// kubeconfig entry is ours to remove afterwards, and the project is needed
+	// for the post-destroy orphan-disk sweep.
 	rec, recErr := ws.ReadRecord()
+	if recErr == nil {
+		// Tear down app workloads first so the CSI driver deletes PVC-backed
+		// Persistent Disks before the node pool dies — otherwise they orphan as
+		// billable leftovers. Best-effort; never blocks the destroy.
+		releaseWorkloadDisks(ctx, rec)
+	}
 	if err := p.engine.Destroy(ctx, ws.TerraformDir()); err != nil {
 		return models.NewClusterOperationError("delete", name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run delete to retry", err, ws.Dir()))
 	}
 	if recErr == nil {
 		_ = removeFromDefaultKubeconfig(rec)
+		// Surface any PVC-provisioned disks that outlived the destroy so a
+		// "cleaned up" delete never silently leaves billable orphans.
+		p.reportOrphanedDisks(ctx, rec.Project, name)
 	}
 	return ws.Remove()
 }

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -126,6 +126,44 @@ func (p *Provider) preflightNameCollision(ctx context.Context, config models.Clu
 	return nil
 }
 
+// firstZoneInRegion returns the alphabetically-first zone of a region (e.g.
+// "us-central1-a"), used as the single location for a zonal cluster. Sorting
+// makes the choice deterministic across runs — a resume must not pick a
+// different zone and try to move the cluster. gcloud is already a hard GKE
+// prerequisite, so this adds no new dependency.
+func (p *Provider) firstZoneInRegion(ctx context.Context, project, region string) (string, error) {
+	res, err := p.executor.Execute(ctx, "gcloud", "compute", "zones", "list",
+		"--project", project,
+		"--filter", "name~^"+region+"-",
+		"--format=value(name)", "--sort-by=name", "--limit=1")
+	if err != nil {
+		return "", fmt.Errorf("listing zones for region %s: %w", region, err)
+	}
+	var zone string
+	if res != nil {
+		zone = strings.TrimSpace(strings.SplitN(strings.TrimSpace(res.Stdout), "\n", 2)[0])
+	}
+	if zone == "" {
+		return "", fmt.Errorf("no zones found for region %q in project %q", region, project)
+	}
+	return zone, nil
+}
+
+// ensureZone fills config.Cloud.Zone for a zonal (non-HA) cluster so the module
+// has a concrete location and the node count is exact. No-op for HA (regional)
+// clusters and when a zone is already set.
+func (p *Provider) ensureZone(ctx context.Context, config *models.ClusterConfig) error {
+	if config.Cloud == nil || config.Cloud.HA || config.Cloud.Zone != "" {
+		return nil
+	}
+	zone, err := p.firstZoneInRegion(ctx, config.Cloud.Project, config.Cloud.Region)
+	if err != nil {
+		return err
+	}
+	config.Cloud.Zone = zone
+	return nil
+}
+
 // backendTF renders the gcs backend block for a GKE workspace.
 func backendTF(cfg tfengine.BackendConfig) []byte {
 	return []byte(fmt.Sprintf(
@@ -157,6 +195,9 @@ func (p *Provider) PlanCluster(ctx context.Context, config models.ClusterConfig)
 		return tfengine.PlanSummary{}, err
 	}
 	if err := p.preflightCredentials(ctx, config.Cloud.Project); err != nil {
+		return tfengine.PlanSummary{}, err
+	}
+	if err := p.ensureZone(ctx, &config); err != nil {
 		return tfengine.PlanSummary{}, err
 	}
 
@@ -194,6 +235,9 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 		return nil, err
 	}
 	if err := p.preflightCredentials(ctx, config.Cloud.Project); err != nil {
+		return nil, err
+	}
+	if err := p.ensureZone(ctx, &config); err != nil {
 		return nil, err
 	}
 

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,6 +20,42 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+// gcpResourcePathRE pulls the GCP resource path (projects/.../<kind>/<name>)
+// out of a terraform 409 error so an orphan can be named concretely.
+var gcpResourcePathRE = regexp.MustCompile(`projects/[^'"\s]+`)
+
+// orphanFromInterruptedCreate detects the specific failure where terraform
+// tries to create a resource that already exists in GCP (HTTP 409 /
+// alreadyExists). This is the signature of a create interrupted (SIGINT) after
+// the cloud API created a resource but before terraform saved it to state: the
+// resource is real but state-invisible, so every resume collides with it (409)
+// and 'cluster delete' — which only knows state-tracked resources — cannot
+// remove it. Returns human-readable remediation and true when this is that
+// case, so the caller can replace the generic "re-run to resume" hint (which
+// would loop forever here) with something actionable.
+func orphanFromInterruptedCreate(err error, terraformDir string) (string, bool) {
+	msg := err.Error()
+	low := strings.ToLower(msg)
+	if !strings.Contains(low, "alreadyexists") && !strings.Contains(low, "409") {
+		return "", false
+	}
+	resource := "the resource named in the error above"
+	if m := gcpResourcePathRE.FindString(msg); m != "" {
+		resource = m
+	}
+	return fmt.Sprintf(
+		"a resource already exists in GCP that terraform is not tracking:\n"+
+			"  %s\n"+
+			"This is the signature of a create that was interrupted after the resource was\n"+
+			"created but before its state was saved — so resume keeps colliding with it and\n"+
+			"'cluster delete' cannot remove it (delete only knows state-tracked resources).\n"+
+			"Resolve it one of two ways, then re-run create:\n"+
+			"  • delete the orphan in GCP (Cloud Console or the matching 'gcloud ... delete'), or\n"+
+			"  • import it into this cluster's state, e.g.:\n"+
+			"      terraform -chdir=%s import <resource.address> %s",
+		resource, terraformDir, resource), true
+}
 
 // Provider provisions and manages GKE clusters.
 type Provider struct {
@@ -230,6 +267,10 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	}
 	if err := p.engine.ApplyPlan(ctx, ws.TerraformDir(), planFile); err != nil {
 		_ = ws.SetStatus(tfengine.StatusFailed)
+		if hint, ok := orphanFromInterruptedCreate(err, ws.TerraformDir()); ok {
+			return nil, models.NewClusterOperationError("create", config.Name,
+				fmt.Errorf("%w\n\n%s", err, hint))
+		}
 		return nil, models.NewClusterOperationError("create", config.Name,
 			fmt.Errorf("%w\nThe terraform state is kept in %s; re-run create to resume or 'openframe cluster delete %s' to tear down", err, ws.Dir(), config.Name))
 	}

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -240,6 +240,53 @@ func TestTfvarsFor_VersionMapping(t *testing.T) {
 	}
 }
 
+// The default cluster is zonal so --nodes N is the exact node count; --ha
+// (HA=true) makes it regional. Zone is passed through to the module.
+func TestTfvarsFor_TopologyMapping(t *testing.T) {
+	zonal := gkeConfig("demo")
+	zonal.Cloud.Zone = "us-central1-a"
+	vars, err := tfvarsFor(zonal)
+	require.NoError(t, err)
+	assert.False(t, vars.Regional, "default must be zonal (exact node count)")
+	assert.Equal(t, "us-central1-a", vars.Zone)
+
+	ha := gkeConfig("demo")
+	ha.Cloud.HA = true
+	vars, err = tfvarsFor(ha)
+	require.NoError(t, err)
+	assert.True(t, vars.Regional, "--ha must produce a regional cluster")
+}
+
+// A zonal cluster resolves a concrete zone from the region via gcloud; the
+// alphabetically-first is chosen deterministically.
+func TestEnsureZone_ResolvesFirstZoneForZonal(t *testing.T) {
+	p, _, _ := newTestProvider(t, nil)
+	mock := executor.NewMockCommandExecutor()
+	mock.SetResponse("gcloud compute zones list", &executor.CommandResult{
+		ExitCode: 0,
+		Stdout:   "us-central1-a\n",
+	})
+	p.executor = mock
+
+	config := gkeConfig("demo")
+	require.NoError(t, p.ensureZone(context.Background(), &config))
+	assert.Equal(t, "us-central1-a", config.Cloud.Zone)
+}
+
+// An HA (regional) cluster needs no single zone; ensureZone must not even query.
+func TestEnsureZone_SkipsForHA(t *testing.T) {
+	p, _, _ := newTestProvider(t, nil)
+	mock := executor.NewMockCommandExecutor()
+	p.executor = mock
+
+	config := gkeConfig("demo")
+	config.Cloud.HA = true
+	require.NoError(t, p.ensureZone(context.Background(), &config))
+	assert.Empty(t, config.Cloud.Zone)
+	assert.False(t, mock.WasCommandExecuted("gcloud compute zones list"),
+		"a regional cluster must not resolve a single zone")
+}
+
 func TestTemplateEmbedsModulePins(t *testing.T) {
 	tf := string(mainTF)
 	assert.Contains(t, tf, `source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"`)

--- a/internal/cluster/providers/gke/teardown.go
+++ b/internal/cluster/providers/gke/teardown.go
@@ -1,0 +1,143 @@
+package gke
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// appNamespaces are the namespaces OpenFrame installs into. They are deleted
+// (argocd first, so its controller stops re-syncing, then openframe) before the
+// infra is destroyed, so the PVCs living in them are removed and the GKE CSI
+// driver deletes their backing Persistent Disks while the cluster is still
+// alive. Order matters — see releaseWorkloadDisks.
+var appNamespaces = []string{"argocd", "openframe"}
+
+// diskDrainTimeout bounds how long a delete waits for PVC-backed disks to be
+// reclaimed before proceeding to destroy anyway. A live-platform teardown must
+// never block indefinitely; anything not drained in time is surfaced by the
+// post-destroy sweep instead.
+const diskDrainTimeout = 4 * time.Minute
+
+// releaseWorkloadDisks deletes the OpenFrame app namespaces on the cluster and
+// waits (bounded) for their PVC-backed PersistentVolumes to drain, so the GKE
+// CSI driver deletes the underlying Persistent Disks BEFORE terraform destroys
+// the node pool. Without this, PVC-provisioned disks — which live outside the
+// terraform state — detach and survive as billable orphans.
+//
+// Entirely best-effort: an unreachable cluster, missing namespaces, RBAC
+// denial, or a drain timeout are all logged and ignored. The infra destroy the
+// user asked for must never be blocked by teardown, and the post-destroy sweep
+// reports anything this misses.
+func releaseWorkloadDisks(ctx context.Context, rec tfengine.Record) {
+	restCfg, err := restConfigFor(rec)
+	if err != nil {
+		pterm.Debug.Printf("skip pre-destroy disk release (no rest config): %v\n", err)
+		return
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		pterm.Debug.Printf("skip pre-destroy disk release (no kube client): %v\n", err)
+		return
+	}
+
+	var deleting []string
+	for _, ns := range appNamespaces {
+		// Short per-call context so an unreachable API server fails fast rather
+		// than hanging the whole delete.
+		getCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		_, err := client.CoreV1().Namespaces().Get(getCtx, ns, metav1.GetOptions{})
+		cancel()
+		if err != nil {
+			continue // absent or unreachable — nothing to release here
+		}
+		delCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		err = client.CoreV1().Namespaces().Delete(delCtx, ns, metav1.DeleteOptions{})
+		cancel()
+		if err == nil || k8serrors.IsNotFound(err) {
+			deleting = append(deleting, ns)
+		}
+	}
+	if len(deleting) == 0 {
+		return // no OpenFrame workloads on the cluster; nothing to drain
+	}
+	pterm.Info.Printf("Releasing persistent disks (removing %s) before destroy...\n", strings.Join(deleting, ", "))
+
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, diskDrainTimeout, true, func(ctx context.Context) (bool, error) {
+		listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		pvs, err := client.CoreV1().PersistentVolumes().List(listCtx, metav1.ListOptions{})
+		if err != nil {
+			return false, nil // transient — keep polling until the outer timeout
+		}
+		return countClaimedPVs(pvs.Items, deleting) == 0, nil
+	})
+}
+
+// countClaimedPVs counts PersistentVolumes still claimed by any of the given
+// namespaces. Once a PVC is deleted its PV is released and (reclaimPolicy
+// Delete) removed, so this reaching zero means the backing disks are gone.
+func countClaimedPVs(pvs []corev1.PersistentVolume, namespaces []string) int {
+	inScope := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		inScope[ns] = struct{}{}
+	}
+	var n int
+	for _, pv := range pvs {
+		ref := pv.Spec.ClaimRef
+		if ref == nil {
+			continue
+		}
+		if _, ok := inScope[ref.Namespace]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+// reportOrphanedDisks lists any Persistent Disks still labeled for this cluster
+// after the destroy and prints them with a cleanup command. It is report-only:
+// the CLI never deletes cloud disks directly, so a user is told the truth
+// ("these survived") instead of a false "fully cleaned up". Best-effort — a
+// gcloud hiccup is silently skipped.
+func (p *Provider) reportOrphanedDisks(ctx context.Context, project, name string) {
+	if project == "" {
+		return
+	}
+	res, err := p.executor.Execute(ctx, "gcloud", "compute", "disks", "list",
+		"--project", project,
+		"--filter", "labels.goog-k8s-cluster-name="+name,
+		"--format=value(name,location,sizeGb)")
+	if err != nil || res == nil {
+		return
+	}
+	disks := parseDiskList(res.Stdout)
+	if len(disks) == 0 {
+		return
+	}
+	pterm.Warning.Printf("%d Persistent Disk(s) labeled for cluster %q survived the destroy (PVC-provisioned, outside terraform state):\n", len(disks), name)
+	for _, d := range disks {
+		pterm.Warning.Printf("  - %s\n", d)
+	}
+	pterm.Warning.Printf("Review and remove them with:\n  gcloud compute disks list --project %s --filter=\"labels.goog-k8s-cluster-name=%s\"\n", project, name)
+}
+
+// parseDiskList turns `gcloud compute disks list --format=value(...)` output
+// into one entry per non-empty line.
+func parseDiskList(out string) []string {
+	var disks []string
+	for _, line := range strings.Split(out, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			disks = append(disks, s)
+		}
+	}
+	return disks
+}

--- a/internal/cluster/providers/gke/teardown_test.go
+++ b/internal/cluster/providers/gke/teardown_test.go
@@ -1,0 +1,43 @@
+package gke
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func pv(ns string) corev1.PersistentVolume {
+	p := corev1.PersistentVolume{}
+	if ns != "" {
+		p.Spec.ClaimRef = &corev1.ObjectReference{Namespace: ns}
+	}
+	return p
+}
+
+func TestCountClaimedPVs(t *testing.T) {
+	pvs := []corev1.PersistentVolume{
+		pv("openframe"),   // in scope
+		pv("openframe"),   // in scope
+		pv("argocd"),      // in scope
+		pv("kube-system"), // out of scope — must not be counted
+		pv(""),            // unbound (no claimRef) — must not be counted
+	}
+	if got := countClaimedPVs(pvs, []string{"argocd", "openframe"}); got != 3 {
+		t.Fatalf("countClaimedPVs = %d, want 3 (only app-namespace claims)", got)
+	}
+	if got := countClaimedPVs(nil, []string{"openframe"}); got != 0 {
+		t.Fatalf("countClaimedPVs(nil) = %d, want 0", got)
+	}
+}
+
+func TestParseDiskList(t *testing.T) {
+	// gcloud value() output: one disk per line, blank lines when there are none.
+	out := "pvc-abc\tus-central1-a\t20\npvc-def\tus-central1-b\t8\n\n"
+	got := parseDiskList(out)
+	if len(got) != 2 {
+		t.Fatalf("parseDiskList returned %d entries, want 2: %v", len(got), got)
+	}
+	if parseDiskList("") != nil || len(parseDiskList("\n \n")) != 0 {
+		t.Fatal("empty/whitespace gcloud output must yield no disks")
+	}
+}

--- a/internal/cluster/providers/gke/template.go
+++ b/internal/cluster/providers/gke/template.go
@@ -20,6 +20,10 @@ type tfvars struct {
 	ClusterName       string `json:"cluster_name"`
 	Project           string `json:"project"`
 	Region            string `json:"region"`
+	// Regional is always emitted (not omitempty): the template default is zonal,
+	// and dropping a false here would be correct-by-accident — keep it explicit.
+	Regional          bool   `json:"regional"`
+	Zone              string `json:"zone,omitempty"`
 	KubernetesVersion string `json:"kubernetes_version,omitempty"`
 	InstanceType      string `json:"instance_type,omitempty"`
 	MinNodes          int    `json:"min_nodes,omitempty"`
@@ -48,6 +52,8 @@ func tfvarsFor(config models.ClusterConfig) (tfvars, error) {
 		ClusterName:       config.Name,
 		Project:           cloud.Project,
 		Region:            cloud.Region,
+		Regional:          cloud.HA,
+		Zone:              cloud.Zone,
 		KubernetesVersion: version,
 		InstanceType:      cloud.MachineType,
 		MinNodes:          cloud.MinNodes,

--- a/internal/cluster/providers/gke/template_guard_test.go
+++ b/internal/cluster/providers/gke/template_guard_test.go
@@ -2,6 +2,7 @@ package gke
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,30 @@ func TestTemplate_NeverManagesTheProject(t *testing.T) {
 func TestTemplate_ProjectIsAnInputVariable(t *testing.T) {
 	require.Contains(t, string(mainTF), `variable "project"`,
 		"the project must be a declared input variable, not a resource the template creates")
+}
+
+// The GKE cluster's subnet/secondary ranges are passed to module.gke as string
+// literals, not module.network outputs, so terraform builds no implicit edge
+// from the cluster to the subnet. module.gke must therefore depend_on
+// module.network explicitly — otherwise destroy can delete the subnet in
+// parallel with the still-running node pool and GCP rejects it. This asserts
+// the ordering edge stays in place.
+func TestTemplate_GKEDependsOnNetworkForDestroyOrdering(t *testing.T) {
+	src := string(mainTF)
+
+	// The literal wiring that removes the implicit edge (the reason the explicit
+	// depends_on is required). If these ever become module.network references,
+	// this guard can be revisited.
+	require.Contains(t, src, `subnetwork        = "${var.cluster_name}-subnet"`,
+		"subnetwork is expected to be a string literal — the premise of the explicit dependency")
+
+	depRE := regexp.MustCompile(`depends_on\s*=\s*\[([^\]]*)\]`)
+	var gkeDep string
+	for _, m := range depRE.FindAllStringSubmatch(src, -1) {
+		if strings.Contains(m[1], "module.network") {
+			gkeDep = m[1]
+		}
+	}
+	require.NotEmpty(t, gkeDep,
+		"module.gke must depend_on module.network so destroy tears the cluster down before the subnet")
 }

--- a/internal/cluster/providers/gke/template_validate_test.go
+++ b/internal/cluster/providers/gke/template_validate_test.go
@@ -22,11 +22,13 @@ func TestTerraformValidate(t *testing.T) {
 		t.Fatalf("the tfvalidate tag requires a terraform binary: %v", err)
 	}
 
+	// A zonal config with a concrete zone — the default topology the provider
+	// produces (ensureZone fills Zone before scaffolding).
 	vars, err := tfvarsFor(models.ClusterConfig{
 		Name:      "validate-only",
 		Type:      models.ClusterTypeGKE,
 		NodeCount: 3,
-		Cloud:     &models.CloudConfig{Region: "us-central1", Project: "validate-only"},
+		Cloud:     &models.CloudConfig{Region: "us-central1", Project: "validate-only", Zone: "us-central1-a"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cluster/providers/gke/templates/main.tf
+++ b/internal/cluster/providers/gke/templates/main.tf
@@ -19,6 +19,22 @@ variable "cluster_name" { type = string }
 variable "project" { type = string }
 variable "region" { type = string }
 
+# regional=false (the default) builds a single-zone cluster in `zone`, so the
+# node pool's counts are the real totals: desired_nodes nodes, not
+# desired_nodes-per-zone. regional=true spreads the control plane and nodes
+# across the region's zones for HA, at ~zones× the node count.
+variable "regional" {
+  type    = bool
+  default = false
+}
+
+# The zone for a zonal (regional=false) cluster, e.g. "us-central1-a". Ignored
+# when regional=true. The CLI fills this from the region.
+variable "zone" {
+  type    = string
+  default = ""
+}
+
 # Kubernetes <major>.<minor> (e.g. "1.33"); empty means the GKE default.
 variable "kubernetes_version" {
   type    = string
@@ -129,7 +145,11 @@ module "gke" {
   project_id = var.project
   name       = var.cluster_name
   region     = var.region
-  regional   = true
+  regional   = var.regional
+  # Zonal clusters need their zone; a regional cluster ignores this and uses the
+  # region's default zone set. zones[0] is also the control-plane zone when
+  # zonal.
+  zones = var.regional ? [] : [var.zone]
 
   network           = module.network.network_name
   subnetwork        = "${var.cluster_name}-subnet"

--- a/internal/cluster/providers/gke/templates/main.tf
+++ b/internal/cluster/providers/gke/templates/main.tf
@@ -165,7 +165,14 @@ module "gke" {
 
   # Private nodes need the NAT for egress (image pulls) from the first boot —
   # nothing else creates an implicit ordering on it.
-  depends_on = [google_compute_router_nat.nat]
+  #
+  # module.network is listed explicitly because subnetwork/ip_range_pods/
+  # ip_range_services are passed as string literals (not module outputs), so
+  # terraform would otherwise build NO edge from the cluster to the subnet.
+  # Without it, destroy can remove the subnet in parallel with the still-running
+  # node pool and GCP rejects it ("subnetwork in use by instance"); the explicit
+  # dependency makes the whole cluster tear down before any network resource.
+  depends_on = [google_compute_router_nat.nat, module.network]
 }
 
 output "cluster_name" {

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -273,9 +273,14 @@ func (s *ClusterService) cloudProviders() []provider.Provider {
 // in the workspace registry.
 func (s *ClusterService) ListClusters() ([]models.ClusterInfo, error) {
 	ctx := context.Background()
+	// k3d enumeration shells out to `k3d cluster list`, which needs a running
+	// Docker daemon. Treat its failure as best-effort (like the cloud loop
+	// below): a stopped Docker must not hide the cloud clusters. The warning
+	// goes to stderr so json/yaml output on stdout stays machine-clean.
 	clusters, err := s.manager.ListAllClusters(ctx)
 	if err != nil {
-		return nil, err
+		pterm.Warning.WithWriter(os.Stderr).Printf("local (k3d) clusters could not be listed (is Docker running?): %v\n", err)
+		clusters = nil
 	}
 	for _, cloud := range s.cloudProviders() {
 		cloudClusters, err := cloud.ListAllClusters(ctx)

--- a/internal/cluster/service_test.go
+++ b/internal/cluster/service_test.go
@@ -84,6 +84,25 @@ func TestClusterService_CreateCluster_CloudWithoutRegionFailsBeforeAnyCommand(t 
 	}
 }
 
+// ListClusters must not hard-fail when local k3d enumeration fails (e.g. the
+// Docker daemon is stopped): a cloud-only user must still be able to list and
+// see status of their GKE/EKS clusters. The k3d error degrades to best-effort.
+func TestClusterService_ListClusters_K3dFailureIsBestEffort(t *testing.T) {
+	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
+	mock := executor.NewMockCommandExecutor()
+	// Simulate Docker down: every k3d shell-out fails.
+	mock.SetShouldFail(true, "Cannot connect to the Docker daemon")
+	service := NewClusterServiceSuppressed(mock)
+
+	clusters, err := service.ListClusters()
+	if err != nil {
+		t.Fatalf("ListClusters must degrade gracefully when k3d fails, got error: %v", err)
+	}
+	if len(clusters) != 0 {
+		t.Fatalf("expected no clusters (k3d down, empty cloud registry), got %d", len(clusters))
+	}
+}
+
 func TestClusterService_DeleteCluster_UnknownCloudClusterIsNotFound(t *testing.T) {
 	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
 	for _, clusterType := range []models.ClusterType{models.ClusterTypeEKS, models.ClusterTypeGKE} {


### PR DESCRIPTION
    The module built a regional cluster, so node counts were per-zone: --nodes 3
    provisioned 3 nodes in each of the region's ~3 zones (~9 total) while every
    display still said 3 — roughly 3x the expected node bill, silently.

    Default to a single-zone cluster (regional=false), so the node pool's counts
    are the real totals and the existing 'Nodes: N' display becomes truthful with
    no display change. The provider resolves a concrete zone from the region via
    gcloud (alphabetically-first, deterministic so a resume never moves the
    cluster). A new --ha flag opts back into a regional, multi-zone control plane
    and node pool for HA.

    NOTE: the terraform template change (regional/zone vars, zones wiring) could
    not be validated in this environment — run 'make test-tfvalidate' (needs a
    terraform binary) before merging.