### PR TITLE
fix(version): identify dev builds from the embedded VCS stamp

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/flamingo-stack/openframe-cli/cmd/app"
@@ -40,10 +41,54 @@ var (
 
 // DefaultVersionInfo provides default version information, populated from the
 // build-time vars above (overridden via -ldflags -X at release time).
-var DefaultVersionInfo = VersionInfo{
-	Version: version,
-	Commit:  commit,
-	Date:    date,
+var DefaultVersionInfo = resolveVersionInfo(version, commit, date)
+
+// resolveVersionInfo returns the build-time version metadata. On a dev build —
+// where the release-time -ldflags were not applied, so commit is "none" and
+// date "unknown" — it backfills them from the VCS stamp Go embeds in every
+// `go build`/`go install`/`make build` binary, so the build is identifiable
+// ("dev (85c7c15f11b9) built on <time>") instead of "dev (none) built on
+// unknown". The version string stays "dev", which is what keeps self-update
+// disabled for non-release builds.
+func resolveVersionInfo(version, commit, date string) VersionInfo {
+	info := VersionInfo{Version: version, Commit: commit, Date: date}
+	if commit != "none" && date != "unknown" {
+		return info // release build — ldflags were applied
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		info = backfillFromVCS(info, bi.Settings)
+	}
+	return info
+}
+
+// backfillFromVCS fills commit/date from Go's embedded VCS settings, but only
+// where they are still at their dev defaults.
+func backfillFromVCS(info VersionInfo, settings []debug.BuildSetting) VersionInfo {
+	var rev, vcsTime string
+	var modified bool
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.time":
+			vcsTime = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if info.Commit == "none" && rev != "" {
+		if len(rev) > 12 {
+			rev = rev[:12]
+		}
+		if modified {
+			rev += "-dirty"
+		}
+		info.Commit = rev
+	}
+	if info.Date == "unknown" && vcsTime != "" {
+		info.Date = vcsTime
+	}
+	return info
 }
 
 // GetRootCmd returns the root command following cluster command pattern

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -47,9 +48,50 @@ func TestRootCommandHelp(t *testing.T) {
 }
 
 func TestRootCommandVersion(t *testing.T) {
-	// Test version flag using testutil
+	// Test version flag using testutil. Only "dev" is asserted: commit and date
+	// are backfilled from the VCS stamp on any build inside a git checkout, so
+	// "none"/"unknown" only appear when no VCS info is embedded.
 	cmd := GetRootCmd(DefaultVersionInfo)
-	testutil.TestCLICommand(t, cmd, []string{"--version"}, false, "dev", "none", "unknown")
+	testutil.TestCLICommand(t, cmd, []string{"--version"}, false, "dev")
+}
+
+func TestBackfillFromVCS(t *testing.T) {
+	dev := VersionInfo{Version: "dev", Commit: "none", Date: "unknown"}
+
+	t.Run("fills commit and date from VCS, truncating the sha", func(t *testing.T) {
+		got := backfillFromVCS(dev, []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "85c7c15f11b9cf079785edace4882b196008d6ee"},
+			{Key: "vcs.time", Value: "2026-07-29T09:21:35Z"},
+			{Key: "vcs.modified", Value: "false"},
+		})
+		if got.Commit != "85c7c15f11b9" {
+			t.Errorf("commit = %q, want truncated sha 85c7c15f11b9", got.Commit)
+		}
+		if got.Date != "2026-07-29T09:21:35Z" {
+			t.Errorf("date = %q, want the vcs.time", got.Date)
+		}
+	})
+
+	t.Run("marks a dirty working tree", func(t *testing.T) {
+		got := backfillFromVCS(dev, []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abcdef1234567890"},
+			{Key: "vcs.modified", Value: "true"},
+		})
+		if got.Commit != "abcdef123456-dirty" {
+			t.Errorf("commit = %q, want abcdef123456-dirty", got.Commit)
+		}
+	})
+
+	t.Run("release values are never overwritten", func(t *testing.T) {
+		release := VersionInfo{Version: "1.2.3", Commit: "realsha", Date: "2026-01-01"}
+		got := backfillFromVCS(release, []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "shouldNotWin"},
+			{Key: "vcs.time", Value: "9999-01-01"},
+		})
+		if got.Commit != "realsha" || got.Date != "2026-01-01" {
+			t.Errorf("release metadata must not be overwritten, got %+v", got)
+		}
+	})
 }
 
 func TestGetRootCmd(t *testing.T) {

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -155,8 +155,10 @@ func (eh *ErrorHandler) handleGenericError(err error) {
 		// Generic error handling
 		pterm.Error.Printf("❌ Operation failed\n")
 		if eh.verbose {
+			// %v already carries the full error chain; the Go type (e.g.
+			// *errors.errorString) is internal noise that only leaked implementation
+			// detail to the user.
 			pterm.Printf("  Details: %v\n", err)
-			pterm.Printf("  Type: %T\n", err)
 		} else {
 			// Show only the essential error message
 			pterm.Printf("  Error: %s\n", errorMsg)


### PR DESCRIPTION
    Dev builds reported 'dev (none) built on unknown' because the release-time
    -ldflags are only applied by goreleaser. Go already stamps vcs.revision/
    vcs.time/vcs.modified into every 'go build'/'go install'/'make build' binary,
    so backfill commit and date from that stamp when they're still at their dev
    defaults. A dev build now reads e.g. 'dev (85c7c15f11b9-dirty) built on
    <time>'. The version string stays 'dev' (which is what keeps self-update
    disabled), and release builds with real ldflags are never overwritten.