### PR TITLE
feat(cluster): pick the GCP project from a list in the create wizard

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -338,10 +338,39 @@ func runCreateCluster(cmd *cobra.Command, args []string) error {
 		if err := discovery.NewAuthFlow(utils.CommandExecutor()).Ensure(cmd.Context(), true); err != nil {
 			return err
 		}
+		// In flag mode the project came from --project, not the wizard's
+		// validated picker, so check it against the accessible projects and fail
+		// fast with the valid options — before terraform runs.
+		if globalFlags.Create.SkipWizard {
+			if err := validateGKEProjectFlag(cmd.Context(), utils.CommandExecutor(), config.Cloud.Project); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Execute cluster creation through service layer
 	// We ignore the returned rest.Config as it's not needed for standalone cluster creation
 	_, err := service.CreateCluster(cmd.Context(), config)
 	return err
+}
+
+// validateGKEProjectFlag checks a --project against the gcloud identity's
+// accessible projects and returns an actionable error (listing the valid
+// options) when it is not among them. Best-effort: if the projects cannot be
+// listed (permissions, network), it returns nil and defers to the provider
+// preflight's 'gcloud projects describe' accessibility check.
+func validateGKEProjectFlag(ctx context.Context, exec executor.CommandExecutor, project string) error {
+	projects, err := discovery.NewGKEDiscoverer(exec).AllProjects(ctx)
+	if err != nil || len(projects) == 0 {
+		return nil // can't enumerate — the provider preflight still validates access
+	}
+	for _, p := range projects {
+		if p == project {
+			return nil
+		}
+	}
+	if len(projects) > 15 {
+		return fmt.Errorf("GCP project %q is not among your %d accessible projects — run 'gcloud projects list' to see them", project, len(projects))
+	}
+	return fmt.Errorf("GCP project %q is not among your accessible projects: %s", project, strings.Join(projects, ", "))
 }

--- a/cmd/cluster/create_project_validation_test.go
+++ b/cmd/cluster/create_project_validation_test.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+)
+
+func TestValidateGKEProjectFlag(t *testing.T) {
+	list := &executor.CommandResult{ExitCode: 0, Stdout: "tenant-y0\nshared-abc\nprod-42\n"}
+
+	t.Run("project in the list passes", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud projects list", list)
+		if err := validateGKEProjectFlag(context.Background(), mock, "shared-abc"); err != nil {
+			t.Fatalf("expected nil for a listed project, got %v", err)
+		}
+	})
+
+	t.Run("project not in the list errors with the valid options", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud projects list", list)
+		err := validateGKEProjectFlag(context.Background(), mock, "typo-proj")
+		if err == nil {
+			t.Fatal("expected an error for an unlisted project")
+		}
+		if !strings.Contains(err.Error(), "typo-proj") || !strings.Contains(err.Error(), "tenant-y0") {
+			t.Fatalf("error should name the bad project and list valid options, got: %v", err)
+		}
+	})
+
+	t.Run("best-effort: a gcloud listing failure does not block create", func(t *testing.T) {
+		mock := executor.NewMockCommandExecutor()
+		mock.SetShouldFail(true, "network down")
+		if err := validateGKEProjectFlag(context.Background(), mock, "anything"); err != nil {
+			t.Fatalf("a gcloud failure must defer to the provider preflight, not block; got %v", err)
+		}
+	})
+}

--- a/internal/cluster/discovery/gke.go
+++ b/internal/cluster/discovery/gke.go
@@ -103,6 +103,33 @@ func (d *GKEDiscoverer) Projects(ctx context.Context) ([]string, error) {
 	return projects, nil
 }
 
+// AllProjects returns every GCP project the active gcloud identity can list
+// (gcloud projects list), sorted and de-duplicated. Unlike Projects — which is
+// scoped to the projects named by the user's gcloud CONFIGURATIONS — this is
+// the full account-wide set, used to populate the create wizard's project
+// picker and to validate a --project flag against the accessible projects.
+func (d *GKEDiscoverer) AllProjects(ctx context.Context) ([]string, error) {
+	result, err := d.exec.Execute(ctx, "gcloud", "projects", "list", "--format=value(projectId)")
+	if err != nil {
+		return nil, fmt.Errorf("listing GCP projects: %w", err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	var projects []string
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		p := strings.TrimSpace(line)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		projects = append(projects, p)
+	}
+	sort.Strings(projects)
+	return projects, nil
+}
+
 // ConfigurationForProject returns the name of the first gcloud configuration
 // pointing at the given project, or "" when none does.
 func (d *GKEDiscoverer) ConfigurationForProject(ctx context.Context, project string) (string, error) {

--- a/internal/cluster/discovery/gke_test.go
+++ b/internal/cluster/discovery/gke_test.go
@@ -65,6 +65,29 @@ func TestProjects_DedupesAndSkipsEmpty(t *testing.T) {
 	assert.Equal(t, []string{"shared-4t5d", "shared-j62b", "tenant-runners-db9z"}, projects)
 }
 
+func TestAllProjects_SortsDedupesAndSkipsEmpty(t *testing.T) {
+	mock := executor.NewMockCommandExecutor()
+	// gcloud projects list --format=value(projectId): one id per line, unsorted,
+	// with a duplicate and blank lines.
+	mock.SetResponse("gcloud projects list", &executor.CommandResult{
+		ExitCode: 0,
+		Stdout:   "tenant-y0\nshared-abc\ntenant-y0\n\n  prod-42  \n",
+	})
+
+	projects, err := NewGKEDiscoverer(mock).AllProjects(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod-42", "shared-abc", "tenant-y0"}, projects)
+}
+
+func TestAllProjects_ErrorsWhenGcloudFails(t *testing.T) {
+	mock := executor.NewMockCommandExecutor()
+	mock.SetShouldFail(true, "not logged in")
+
+	_, err := NewGKEDiscoverer(mock).AllProjects(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing GCP projects")
+}
+
 func TestDiscover_ListsClustersAcrossProjects(t *testing.T) {
 	kubeconfigWith(t, map[string]string{
 		"connectgateway_tenant-runners-db9z_us-central1_tenant-cluster-1": "",

--- a/internal/cluster/ui/wizard_steps.go
+++ b/internal/cluster/ui/wizard_steps.go
@@ -1,10 +1,13 @@
 package ui
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/discovery"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	sharedUI "github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/manifoldco/promptui"
 	"github.com/pterm/pterm"
@@ -77,8 +80,39 @@ func (ws *WizardSteps) PromptClusterType() (models.ClusterType, error) {
 	}
 }
 
-// PromptProject prompts for the GCP project a GKE cluster lands in.
+// listSelectableProjects fetches the account's GCP projects for the wizard
+// picker. It is a package var so tests can inject a fake list without a real
+// gcloud; it returns nil on any error, which makes PromptProject fall back to
+// free-text entry.
+var listSelectableProjects = func(ctx context.Context) []string {
+	projects, err := discovery.NewGKEDiscoverer(executor.NewRealCommandExecutor(false, false)).AllProjects(ctx)
+	if err != nil {
+		return nil
+	}
+	return projects
+}
+
+// manualProjectChoice is the picker's escape hatch to type a project ID that
+// the list didn't include (e.g. a project the identity can use but not list).
+const manualProjectChoice = "↳ enter a project ID manually…"
+
+// PromptProject asks for the GCP project a GKE cluster lands in. Interactively,
+// when gcloud can enumerate the account's projects, it offers a picker (with a
+// manual-entry escape hatch) so the user selects rather than retypes a project
+// ID. It falls back to free-text entry when non-interactive, when no projects
+// are listed, or when gcloud errors.
 func (ws *WizardSteps) PromptProject() (string, error) {
+	if !sharedUI.IsNonInteractive() {
+		if projects := listSelectableProjects(context.Background()); len(projects) > 0 {
+			_, choice, err := sharedUI.SelectFromList("GCP Project", append(projects, manualProjectChoice))
+			if err != nil {
+				return "", err
+			}
+			if choice != manualProjectChoice {
+				return strings.TrimSpace(choice), nil
+			}
+		}
+	}
 	prompt := promptui.Prompt{
 		Label:    "GCP Project",
 		Validate: sharedUI.ValidateNonEmpty("project"),


### PR DESCRIPTION
Typing a GCP project ID free-hand is error-prone. The wizard now offers a picker populated from 'gcloud projects list' (with a manual-entry escape hatch), falling back to free-text entry when non-interactive, when no projects are listed, or when gcloud errors.

In flag mode (--skip-wizard) the project comes from --project instead of the picker, so validate it against the accessible projects and fail fast with the valid options before terraform runs. Best-effort: if the projects can't be listed, the provider preflight's 'gcloud projects describe' still guards accessibility.

Adds GKEDiscoverer.AllProjects (account-wide 'gcloud projects list', sorted and de-duplicated) — distinct from the config-scoped Projects.