### PR TITLE
fix(download): fail loudly when a pinned archive lacks Tarball/Zip

### DIFF
--- a/internal/shared/download/pins.go
+++ b/internal/shared/download/pins.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Pinned tool definitions replace the unverified "curl | bash" / "curl -o
@@ -192,10 +193,30 @@ func (d Downloader) InstallPinnedTool(ctx context.Context, tool PinnedTool, binD
 		}
 		return dest, nil
 	}
+	// Guard the raw-binary path: an asset that is actually an archive
+	// (.tar.gz/.tgz/.zip) but has neither Tarball nor Zip set would otherwise be
+	// written verbatim — installing the compressed archive bytes AS the
+	// executable. Fail loudly so a misconfigured pin is caught here, not as a
+	// corrupt binary later. (Infracost is a tar.gz but is installed via
+	// InstallVerifiedTarGz directly, bypassing this function — see its pin.)
+	if isArchiveAsset(asset.URL) {
+		return "", fmt.Errorf("pinned tool %q asset %s is an archive but sets neither Tarball nor Zip; refusing to install archive bytes as a binary", tool.Name, asset.URL)
+	}
 	if err := d.InstallVerified(ctx, asset, dest, 0o750); err != nil {
 		return "", err
 	}
 	return dest, nil
+}
+
+// isArchiveAsset reports whether a pinned asset URL points at a compressed
+// archive that must be extracted (Tarball/Zip), not installed as a raw binary.
+func isArchiveAsset(url string) bool {
+	for _, ext := range []string{".tar.gz", ".tgz", ".zip"} {
+		if strings.HasSuffix(url, ext) {
+			return true
+		}
+	}
+	return false
 }
 
 // exeName appends the Windows executable suffix where the OS requires it —

--- a/internal/shared/download/pins_test.go
+++ b/internal/shared/download/pins_test.go
@@ -333,4 +333,47 @@ func TestInfracost_Pins(t *testing.T) {
 			t.Errorf("%s/%s: URL %q must contain version and end with platform.tar.gz", p.os, p.arch, asset.URL)
 		}
 	}
+	// Infracost is a .tar.gz but INTENTIONALLY does not set Tarball: its archive
+	// member layout is irregular, so it is installed via InstallVerifiedTarGz
+	// directly (see the pin comment), never through InstallPinnedTool's tarball
+	// convention. This asserts the intent so a "helpful" Tarball: true — which
+	// would look for the wrong member and break the install — is caught.
+	if Infracost.Tarball || Infracost.Zip {
+		t.Error("Infracost must not set Tarball/Zip: it is installed via InstallVerifiedTarGz, not InstallPinnedTool")
+	}
+}
+
+func TestIsArchiveAsset(t *testing.T) {
+	for _, u := range []string{"https://x/tool-linux-amd64.tar.gz", "https://x/tool.tgz", "https://x/tool_amd64.zip"} {
+		if !isArchiveAsset(u) {
+			t.Errorf("%q must be detected as an archive", u)
+		}
+	}
+	for _, u := range []string{"https://x/tool-linux-amd64", "https://x/tool.exe", "https://x/k3d-darwin-arm64"} {
+		if isArchiveAsset(u) {
+			t.Errorf("%q is a raw binary, not an archive", u)
+		}
+	}
+}
+
+// A pinned archive that forgets Tarball/Zip must fail loudly at install time,
+// not silently write the compressed bytes as the executable.
+func TestInstallPinnedTool_RefusesUnflaggedArchive(t *testing.T) {
+	tool := PinnedTool{
+		Name:    "bogus",
+		Version: "v1.0.0",
+		Assets: map[string]PinnedAsset{
+			runtime.GOOS + "/" + runtime.GOARCH: {
+				URL:    "https://example.invalid/bogus-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz",
+				SHA256: strings.Repeat("a", 64),
+			},
+		},
+	}
+	_, err := (Downloader{}).InstallPinnedTool(context.Background(), tool, t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a .tar.gz asset with neither Tarball nor Zip set")
+	}
+	if !strings.Contains(err.Error(), "archive") {
+		t.Fatalf("error should explain the archive misconfiguration, got: %v", err)
+	}
 }


### PR DESCRIPTION
InstallPinnedTool's fall-through path writes the asset bytes verbatim as the executable. A pinned asset that is actually a .tar.gz/.zip but sets neither Tarball nor Zip would therefore install the compressed archive AS the binary. Guard the raw-binary path: refuse an archive asset that has no extraction flag, so a misconfigured pin fails at install time instead of producing a corrupt executable.

Addresses CodeRabbit's concern on PR #223 (Infracost pin) — but at the right layer: Infracost intentionally omits Tarball (its irregular member layout means it is installed via InstallVerifiedTarGz directly, bypassing this function), so setting Tarball: true as suggested would look for the wrong member and break the install. A test now locks that intent.