### PR TITLE
fix(app): make a stuck app-install fail with a diagnostic, not an opaque hang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -600,6 +600,11 @@ jobs:
         if: matrix.os != 'darwin'
         shell: bash
         timeout-minutes: 40
+        env:
+          # Cap the CLI's app-wait below this step's 40m limit so it fails with
+          # its OWN diagnostic (stuck apps + health messages) instead of being
+          # killed opaquely by the job timeout.
+          OPENFRAME_APP_WAIT_TIMEOUT: 35m
         run: |
           echo "==================================================================="
           echo "===  TEST: real app install (non-interactive, full ArgoCD wait)"

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -157,7 +158,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	startTime := time.Now()
 	timeout := m.waitTimeout
 	if timeout <= 0 {
-		timeout = 60 * time.Minute // default, sized for a fresh install
+		timeout = defaultAppWaitTimeout()
 	}
 	checkInterval := 2 * time.Second
 	lastCheck := time.Now()
@@ -218,8 +219,9 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	// that never became ready. The loop had this all along and threw it away:
 	// "timeout waiting for ArgoCD applications after 1h0m0s" told the user
 	// nothing about which of the apps was stuck, or what to run next.
-	var lastNotReadyApps []string  // decorated "name (Health: X)" labels, for the list
-	var lastNotReadyNames []string // bare names, for the kubectl example
+	var lastNotReadyApps []string    // decorated "name (Health: X)" labels, for the list
+	var lastNotReadyNames []string   // bare names, for the kubectl example
+	var lastNotReadyDetails []string // per-app health messages, for the timeout diagnostic
 	lastReadyCount, lastTotalApps := 0, 0
 	// The spinner already animates for interactive users, so the textual line is
 	// mainly a heartbeat for logs and CI; verbose users want it more often.
@@ -242,7 +244,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 					spinnerStopped = true
 				}
 				spinnerMutex.Unlock()
-				return timeoutError(timeout, lastReadyCount, lastTotalApps, lastNotReadyApps, lastNotReadyNames)
+				return timeoutError(timeout, lastReadyCount, lastTotalApps, lastNotReadyApps, lastNotReadyNames, lastNotReadyDetails)
 			}
 
 			// Periodic cluster health check
@@ -377,6 +379,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 			notReadyApps := assess.notReady
 			lastNotReadyApps, lastReadyCount, lastTotalApps = notReadyApps, currentlyReady, totalApps
 			lastNotReadyNames = assess.notReadyNames
+			lastNotReadyDetails = notReadyDiagnostics(apps)
 
 			// Fail fast on deterministic manifest errors (see fatalmanifest.go):
 			// once an app has shown the same "content missing at this revision"
@@ -858,7 +861,7 @@ const maxAppsInTimeoutError = 10
 // must be kept separate: feeding a decorated label into `kubectl describe
 // application` produced `kubectl describe application argocd-apps (Health:
 // Progressing) -n argocd`, which is not a runnable command.
-func timeoutError(timeout time.Duration, ready, total int, notReadyLabels, notReadyNames []string) error {
+func timeoutError(timeout time.Duration, ready, total int, notReadyLabels, notReadyNames, notReadyDetails []string) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "timeout after %s waiting for ArgoCD applications", timeout)
 	if total > 0 {
@@ -875,9 +878,57 @@ func timeoutError(timeout time.Duration, ready, total int, notReadyLabels, notRe
 		fmt.Fprintf(&b, "; still not ready: %s%s", strings.Join(shown, ", "), suffix)
 	}
 
+	// Per-app health messages say WHY (e.g. a CrashLoopBackOff pod for a
+	// Degraded+Synced app), so the timeout is actionable rather than opaque.
+	if len(notReadyDetails) > 0 {
+		b.WriteString("\nWhy they are not ready:")
+		for _, d := range notReadyDetails {
+			b.WriteString("\n" + d)
+		}
+	}
+
 	b.WriteString("\nInspect them with: kubectl get applications -n argocd")
 	if len(notReadyNames) > 0 {
 		fmt.Fprintf(&b, "\nDetails for one: kubectl describe application %s -n argocd", notReadyNames[0])
 	}
 	return fmt.Errorf("%s", b.String())
+}
+
+// defaultAppWaitTimeout is the install/bootstrap application-wait budget: 60m,
+// overridable via OPENFRAME_APP_WAIT_TIMEOUT (a Go duration, e.g. "35m"). A CI
+// job with a shorter step cap sets it so the CLI hits its OWN timeout — and
+// prints its diagnostic — before the job is killed opaquely. The upgrade path
+// is unaffected: it sets an explicit WithWaitTimeout (>0), so this default
+// branch never runs there.
+func defaultAppWaitTimeout() time.Duration {
+	const fallback = 60 * time.Minute
+	if v := strings.TrimSpace(os.Getenv("OPENFRAME_APP_WAIT_TIMEOUT")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return fallback
+}
+
+// notReadyDiagnostics returns one diagnostic line per not-ready application,
+// carrying ArgoCD's health message — which for a Degraded workload names the
+// failing resource/pod — so a timeout explains WHY, not just which app. The
+// message is trimmed to keep the error readable.
+func notReadyDiagnostics(apps []Application) []string {
+	const maxMsg = 300
+	var out []string
+	for _, app := range apps {
+		if app.Health == ArgoCDHealthHealthy && app.Sync == ArgoCDSyncSynced {
+			continue
+		}
+		line := fmt.Sprintf("  - %s: health=%s sync=%s", app.Name, app.Health, app.Sync)
+		if msg := strings.TrimSpace(app.HealthMessage); msg != "" {
+			if len(msg) > maxMsg {
+				msg = msg[:maxMsg] + "…"
+			}
+			line += "\n      " + strings.ReplaceAll(msg, "\n", "\n      ")
+		}
+		out = append(out, line)
+	}
+	return out
 }

--- a/internal/chart/providers/argocd/wait_progress_test.go
+++ b/internal/chart/providers/argocd/wait_progress_test.go
@@ -13,7 +13,7 @@ import (
 func TestTimeoutError_NamesTheStuckApplications(t *testing.T) {
 	err := timeoutError(30*time.Minute, 4, 6,
 		[]string{"openframe-api (Health: Progressing)", "openframe-ui (Health: Degraded)"},
-		[]string{"openframe-api", "openframe-ui"})
+		[]string{"openframe-api", "openframe-ui"}, nil)
 
 	msg := err.Error()
 	for _, want := range []string{
@@ -37,7 +37,7 @@ func TestTimeoutError_NamesTheStuckApplications(t *testing.T) {
 func TestTimeoutError_KubectlHintUsesBareName(t *testing.T) {
 	msg := timeoutError(time.Minute, 14, 17,
 		[]string{"argocd-apps (Health: Progressing)"},
-		[]string{"argocd-apps"}).Error()
+		[]string{"argocd-apps"}, nil).Error()
 
 	if !strings.Contains(msg, "kubectl describe application argocd-apps -n argocd") {
 		t.Errorf("the kubectl hint must use the bare app name; got:\n%s", msg)
@@ -55,7 +55,7 @@ func TestTimeoutError_BoundsTheApplicationList(t *testing.T) {
 		many = append(many, "app-"+string(rune('a'+i)))
 	}
 
-	msg := timeoutError(time.Minute, 0, 25, many, many).Error()
+	msg := timeoutError(time.Minute, 0, 25, many, many, nil).Error()
 
 	if !strings.Contains(msg, "and 15 more") {
 		t.Errorf("the list must be truncated with a count of the remainder; got:\n%s", msg)
@@ -71,7 +71,7 @@ func TestTimeoutError_BoundsTheApplicationList(t *testing.T) {
 // TestTimeoutError_NoAppsIsStillLegible: timing out before any application was
 // observed (app-of-apps never produced children) must not print an empty list.
 func TestTimeoutError_NoAppsIsStillLegible(t *testing.T) {
-	msg := timeoutError(time.Minute, 0, 0, nil, nil).Error()
+	msg := timeoutError(time.Minute, 0, 0, nil, nil, nil).Error()
 
 	if strings.Contains(msg, "still not ready:") {
 		t.Errorf("an empty list must be omitted, not printed empty; got:\n%s", msg)
@@ -82,4 +82,50 @@ func TestTimeoutError_NoAppsIsStillLegible(t *testing.T) {
 	if !strings.Contains(msg, "timeout after 1m0s") {
 		t.Errorf("the message must still state the timeout; got:\n%s", msg)
 	}
+}
+
+// The timeout error must carry per-app health messages so a Degraded app's
+// failing pod is named (why it hung), not just that it hung.
+func TestTimeoutError_IncludesHealthMessages(t *testing.T) {
+	details := notReadyDiagnostics([]Application{
+		{Name: "tenant", Health: ArgoCDHealthDegraded, Sync: ArgoCDSyncSynced,
+			HealthMessage: "pod openframe-stream-abc123 is in CrashLoopBackOff"},
+		{Name: "cassandra", Health: ArgoCDHealthHealthy, Sync: ArgoCDSyncSynced}, // ready — excluded
+	})
+	msg := timeoutError(time.Minute, 15, 17,
+		[]string{"tenant (Health: Degraded)"}, []string{"tenant"}, details).Error()
+
+	for _, want := range []string{
+		"Why they are not ready:",
+		"tenant: health=Degraded sync=Synced",
+		"openframe-stream-abc123 is in CrashLoopBackOff",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout error must contain %q; got:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "cassandra") {
+		t.Errorf("a ready app must not appear in the diagnostics; got:\n%s", msg)
+	}
+}
+
+func TestDefaultAppWaitTimeout_EnvOverride(t *testing.T) {
+	t.Run("defaults to 60m when unset", func(t *testing.T) {
+		t.Setenv("OPENFRAME_APP_WAIT_TIMEOUT", "")
+		if got := defaultAppWaitTimeout(); got != 60*time.Minute {
+			t.Fatalf("default = %v, want 60m", got)
+		}
+	})
+	t.Run("honours a valid duration", func(t *testing.T) {
+		t.Setenv("OPENFRAME_APP_WAIT_TIMEOUT", "35m")
+		if got := defaultAppWaitTimeout(); got != 35*time.Minute {
+			t.Fatalf("override = %v, want 35m", got)
+		}
+	})
+	t.Run("ignores garbage and falls back", func(t *testing.T) {
+		t.Setenv("OPENFRAME_APP_WAIT_TIMEOUT", "not-a-duration")
+		if got := defaultAppWaitTimeout(); got != 60*time.Minute {
+			t.Fatalf("garbage override = %v, want fallback 60m", got)
+		}
+	})
 }


### PR DESCRIPTION
When an ArgoCD app is stuck Degraded+Synced (resources applied, workload CrashLoopBackOff — e.g. openframe-stream on the platform's config/image skew), the install wait rode out the full 60m default. In CI that is longer than the 40m job cap, so GitHub Actions killed the step with an opaque 'action has timed out', and the CLI's own app-status diagnostic never showed.

Safe minimum (no auto-abort on Degraded — transient Degraded during a fresh install is normal, so waiting stays correct):
- the install/bootstrap wait budget is now overridable via OPENFRAME_APP_WAIT_TIMEOUT (a Go duration); default stays 60m, and the upgrade path (explicit WithWaitTimeout) is unaffected;
- the timeout error now carries each not-ready app's ArgoCD health message, which names the failing pod, so it says WHY it hung, not just which app;
- the CI 'real app install' step sets OPENFRAME_APP_WAIT_TIMEOUT=35m (below its 40m cap) so the CLI fails first, printing that diagnostic.