### PR TITLE
fix(cmd): working --verbose under app/cluster, --silent stops leaking the admin password, bootstrap installs onto the right context

### DIFF
--- a/cmd/app/access.go
+++ b/cmd/app/access.go
@@ -78,11 +78,13 @@ func newArgoCDManager(contextName string, verbose bool) (*argocd.Manager, error)
 }
 
 // printAccess renders the ArgoCD sign-in details and how to reach the UI.
+// Everything goes through printers that SetSilent rewires: raw pterm.Printf
+// writes straight to stdout, which leaked the admin PASSWORD under --silent.
 func printAccess(password string) {
 	pterm.DefaultSection.Println("ArgoCD access")
-	pterm.Printf("  Username: admin\n")
-	pterm.Printf("  Password: %s\n", password)
+	pterm.DefaultBasicText.Printf("  Username: admin\n")
+	pterm.DefaultBasicText.Printf("  Password: %s\n", password)
 	pterm.Info.Println("Open the ArgoCD UI:")
-	pterm.Printf("  1. kubectl port-forward -n argocd svc/argocd-server 8080:443\n")
-	pterm.Printf("  2. open https://localhost:8080\n")
+	pterm.DefaultBasicText.Printf("  1. kubectl port-forward -n argocd svc/argocd-server 8080:443\n")
+	pterm.DefaultBasicText.Printf("  2. open https://localhost:8080\n")
 }

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -23,10 +23,11 @@ Examples:
   openframe app install my-cluster`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// This command group defines its own PersistentPreRunE, which shadows
-			// the root's, so honor --silent here too.
-			if s, _ := cmd.Flags().GetBool("silent"); s {
-				ui.SetSilent()
-			}
+			// the root's (cobra runs only the closest parent's hook), so apply
+			// the global --silent AND --verbose contract here too — replicating
+			// only the silent half left `app install --verbose` with zero debug
+			// output while `bootstrap --verbose` printed everything.
+			ui.ApplyGlobalOutputFlags(cmd)
 			// Machine output (json/yaml): no logo, clean stdout for scripts.
 			if isMachineOutput(cmd) {
 				return nil

--- a/cmd/app/app_test.go
+++ b/cmd/app/app_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,4 +30,21 @@ func TestChartRootCommand(t *testing.T) {
 	// Test that help contains expected content
 	assert.Contains(t, cmd.Short, "OpenFrame application")
 	assert.Contains(t, cmd.Long, "Install the OpenFrame application")
+}
+
+// Cobra runs only the CLOSEST parent's PersistentPreRunE, so the app group's
+// hook shadows the root's — it must apply --verbose itself, or every `app`
+// subcommand has zero debug output while `bootstrap --verbose` prints it all.
+func TestAppGroup_PersistentPreRunEHonorsVerbose(t *testing.T) {
+	t.Cleanup(pterm.DisableDebugMessages)
+	dummy := &cobra.Command{Use: "status"}
+	dummy.Flags().Bool("silent", false, "")
+	dummy.Flags().Bool("verbose", true, "")
+	dummy.Flags().String("output", "json", "") // machine mode: skip the logo
+	if err := GetAppCmd().PersistentPreRunE(dummy, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !pterm.PrintDebugMessages {
+		t.Fatal("--verbose must survive the app group's shadowing hook")
+	}
 }

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -74,9 +74,13 @@ type statusAppJSON struct {
 
 // statusJSON is the machine-readable shape of `app status`.
 type statusJSON struct {
-	Reachable    bool            `json:"reachable"`
-	NodesReady   int             `json:"nodesReady"`
-	NodesTotal   int             `json:"nodesTotal"`
+	Reachable  bool `json:"reachable"`
+	NodesReady int  `json:"nodesReady"`
+	NodesTotal int  `json:"nodesTotal"`
+	// HealthError says WHY reachable is false (e.g. an RBAC-denied node read
+	// next to a fully populated applications array) — without it that
+	// combination read as self-contradictory output.
+	HealthError  string          `json:"healthError,omitempty"`
 	Ready        bool            `json:"ready"`
 	Summary      string          `json:"summary"`
 	Total        int             `json:"total"`
@@ -90,8 +94,13 @@ func statusToJSON(rep appstatus.Report) statusJSON {
 	for _, a := range rep.Apps {
 		apps = append(apps, statusAppJSON{Name: a.Name, Sync: a.Sync, Health: a.Health})
 	}
+	healthErr := ""
+	if rep.HealthErr != nil {
+		healthErr = rep.HealthErr.Error()
+	}
 	return statusJSON{
 		Reachable:    rep.Health.Reachable,
+		HealthError:  healthErr,
 		NodesReady:   rep.Health.NodesReady,
 		NodesTotal:   rep.Health.NodesTotal,
 		Ready:        rep.Ready(),
@@ -104,11 +113,26 @@ func statusToJSON(rep appstatus.Report) statusJSON {
 }
 
 func renderStatus(rep appstatus.Report) {
-	if !rep.Health.Reachable {
+	switch {
+	case !rep.Health.Reachable && rep.Total == 0:
 		pterm.Error.Println("Cluster is not reachable. Is it running and is your kube-context correct?")
+		if rep.HealthErr != nil {
+			pterm.Error.Printf("  cause: %v\n", rep.HealthErr)
+		}
 		return
+	case !rep.Health.Reachable:
+		// The application list DID come back, so the API server answered — only
+		// the node read failed (commonly RBAC: a namespace-scoped credential
+		// has no cluster-wide "nodes list"). Say that and keep the data instead
+		// of claiming the cluster is down and hiding a healthy platform.
+		msg := "Cluster node health could not be read"
+		if rep.HealthErr != nil {
+			msg += ": " + rep.HealthErr.Error()
+		}
+		pterm.Warning.Println(msg)
+	default:
+		pterm.Success.Printf("Cluster reachable (%d/%d nodes ready)\n", rep.Health.NodesReady, rep.Health.NodesTotal)
 	}
-	pterm.Success.Printf("Cluster reachable (%d/%d nodes ready)\n", rep.Health.NodesReady, rep.Health.NodesTotal)
 
 	if rep.Total == 0 {
 		pterm.Warning.Println("No OpenFrame applications found — is it installed? Run: openframe app install")

--- a/cmd/app/status_access_test.go
+++ b/cmd/app/status_access_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"fmt"
 	"testing"
 
+	appstatus "github.com/flamingo-stack/openframe-cli/internal/app/status"
 	"github.com/spf13/cobra"
 )
 
@@ -82,5 +84,18 @@ func TestAppCommand_RegistersStatusAndAccess(t *testing.T) {
 		if !found {
 			t.Errorf("app command does not register %q subcommand", name)
 		}
+	}
+}
+
+// reachable=false next to a populated applications array was self-contradictory
+// machine output; healthError now says why (e.g. an RBAC-denied node read).
+func TestStatusToJSON_CarriesHealthError(t *testing.T) {
+	rep := appstatus.Report{HealthErr: fmt.Errorf("nodes is forbidden")}
+	j := statusToJSON(rep)
+	if j.HealthError != "nodes is forbidden" {
+		t.Fatalf("HealthError = %q", j.HealthError)
+	}
+	if statusToJSON(appstatus.Report{}).HealthError != "" {
+		t.Fatal("no health error → field stays empty (omitted from JSON)")
 	}
 }

--- a/cmd/app/upgrade.go
+++ b/cmd/app/upgrade.go
@@ -147,6 +147,12 @@ func runUpgradeForceSync(cmd *cobra.Command, args []string, flags *InstallFlags,
 		ClusterName:    clusterName,
 		Verbose:        verbose,
 		NonInteractive: flags.NonInteractive,
+		// This IS the force-sync path: on a stall the wait must sync the
+		// stragglers itself. Without this flag it printed the no-sync-mode hint
+		// — advising the user to run `app upgrade --sync`, the very command
+		// they were already running — and rode a straggler (e.g. a child whose
+		// sync patch failed) out to the full 15m timeout.
+		SyncStragglersOnStall: true,
 	}
 	if err := manager.WaitForApplications(cmd.Context(), waitCfg); err != nil {
 		return sharedErrors.HandleGlobalError(err, verbose)

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -34,10 +34,11 @@ Examples:
   openframe cluster delete`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// This command group defines its own PersistentPreRunE, which shadows
-			// the root's, so honor --silent here too.
-			if s, _ := cmd.Flags().GetBool("silent"); s {
-				ui.SetSilent()
-			}
+			// the root's (cobra runs only the closest parent's hook), so apply
+			// the global --silent AND --verbose contract here too — replicating
+			// only the silent half left every cluster subcommand with zero
+			// debug output under --verbose.
+			ui.ApplyGlobalOutputFlags(cmd)
 			// Machine output (json/yaml) is machine mode: no logo, no prerequisite
 			// gate, so stdout stays clean for scripts.
 			if out, _ := cmd.Flags().GetString("output"); out == "json" || out == "yaml" {

--- a/cmd/cluster/cluster_test.go
+++ b/cmd/cluster/cluster_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -13,4 +15,21 @@ func init() {
 func TestClusterRootCommand(t *testing.T) {
 	// Test the root cluster command (no setup needed for root command)
 	testutil.TestClusterCommand(t, "cluster", GetClusterCmd, nil, nil)
+}
+
+// Cobra runs only the CLOSEST parent's PersistentPreRunE, so the cluster
+// group's hook shadows the root's — it must apply --verbose itself, or every
+// `cluster` subcommand has zero debug output.
+func TestClusterGroup_PersistentPreRunEHonorsVerbose(t *testing.T) {
+	t.Cleanup(pterm.DisableDebugMessages)
+	dummy := &cobra.Command{Use: "status"}
+	dummy.Flags().Bool("silent", false, "")
+	dummy.Flags().Bool("verbose", true, "")
+	dummy.Flags().String("output", "json", "") // machine mode: skip logo and gates
+	if err := GetClusterCmd().PersistentPreRunE(dummy, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !pterm.PrintDebugMessages {
+		t.Fatal("--verbose must survive the cluster group's shadowing hook")
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,18 +122,13 @@ operation for automation and power users.`,
 		// Apply --silent before any command runs so it honors its contract
 		// ("suppress all output except errors") across every subcommand.
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			silent, _ := cmd.Flags().GetBool("silent")
-			if silent {
-				ui.SetSilent()
-			}
-			// --verbose enables pterm's Debug printer. Without this the ~35
+			// --verbose enables pterm's Debug printer. Without this the ~40
 			// pterm.Debug call sites across the codebase (executed helm/k3d
 			// command lines, ArgoCD wait internals, prerequisite decisions)
-			// print NOTHING, ever — the diagnostics were written but never
-			// reachable. --silent wins when both are given.
-			if v, _ := cmd.Flags().GetBool("verbose"); v && !silent {
-				pterm.EnableDebugMessages()
-			}
+			// print NOTHING, ever. NOTE: cobra runs only the CLOSEST parent's
+			// PersistentPreRunE — command groups with their own hook (app,
+			// cluster) shadow this one and must call the same helper.
+			ui.ApplyGlobalOutputFlags(cmd)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -9,6 +9,7 @@ import (
 	chartServices "github.com/flamingo-stack/openframe-cli/internal/chart/services"
 	utilTypes "github.com/flamingo-stack/openframe-cli/internal/chart/utils/types"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster"
+	"github.com/flamingo-stack/openframe-cli/internal/k8s"
 	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
 	"github.com/pterm/pterm"
@@ -111,7 +112,18 @@ func (s *Service) createClusterSuppressed(ctx context.Context, clusterName strin
 
 // installChart installs charts on the created cluster
 func (s *Service) installChart(ctx context.Context, clusterName string, nonInteractive, verbose bool, kubeConfig *rest.Config) error {
-	return chartServices.InstallChartsWithConfigContext(ctx, utilTypes.InstallationRequest{
+	return chartServices.InstallChartsWithConfigContext(ctx, bootstrapInstallRequest(clusterName, nonInteractive, verbose, kubeConfig))
+}
+
+// bootstrapInstallRequest builds the chart-install request for the cluster the
+// bootstrap just created. KubeContext must be set alongside KubeConfig: the
+// workflow ignores Args entirely once a rest.Config is provided, so without it
+// the target name came through empty — the interactive confirmation asked
+// "install OpenFrame chart on ''?" and every helm call ran WITHOUT
+// --kube-context, silently targeting the kubeconfig's current context instead
+// of the cluster the native client was pointed at.
+func bootstrapInstallRequest(clusterName string, nonInteractive, verbose bool, kubeConfig *rest.Config) utilTypes.InstallationRequest {
+	return utilTypes.InstallationRequest{
 		Args:           []string{clusterName},
 		Force:          false,
 		DryRun:         false,
@@ -121,8 +133,9 @@ func (s *Service) installChart(ctx context.Context, clusterName string, nonInter
 		CertDir:        "",                           // Auto-detected
 		NonInteractive: nonInteractive,
 		KubeConfig:     kubeConfig,
+		KubeContext:    k8s.ResolveContextForCluster(k8s.DefaultKubeconfigPath(), clusterName),
 		// Inject cluster access from the orchestrator (composition root) so the
 		// app subsystem stays isolated from cluster-creation code (req 18/19).
 		ClusterAccess: cluster.NewClusterService(executor.NewRealCommandExecutor(false, verbose)),
-	})
+	}
 }

--- a/internal/bootstrap/service_test.go
+++ b/internal/bootstrap/service_test.go
@@ -1,12 +1,14 @@
 package bootstrap
 
 import (
+	"path/filepath"
 	"testing"
 
 	appCmd "github.com/flamingo-stack/openframe-cli/cmd/app"
 	clusterCmd "github.com/flamingo-stack/openframe-cli/cmd/cluster"
 	"github.com/flamingo-stack/openframe-cli/tests/testutil"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -144,3 +146,21 @@ func TestServiceVerboseFlagHandling(t *testing.T) {
 // testing. The service coordinates existing cluster and chart commands, so
 // testing focuses on structure and method availability rather than end-to-end
 // execution which would require complex mocking of the underlying commands.
+
+// KubeContext must ride alongside KubeConfig: the chart workflow ignores Args
+// once a rest.Config is provided, so without it the confirmation prompt read
+// "install OpenFrame chart on ''?" and helm ran without --kube-context,
+// targeting whatever context was current instead of the created cluster.
+func TestBootstrapInstallRequest_SetsKubeContext(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "config")) // no entries → k3d- fallback
+	req := bootstrapInstallRequest("demo", true, false, &rest.Config{})
+	if req.KubeContext != "k3d-demo" {
+		t.Fatalf("KubeContext = %q, want k3d-demo", req.KubeContext)
+	}
+	if len(req.Args) != 1 || req.Args[0] != "demo" {
+		t.Fatalf("Args = %v", req.Args)
+	}
+	if req.KubeConfig == nil {
+		t.Fatal("KubeConfig must be passed through")
+	}
+}

--- a/internal/chart/providers/argocd/degraded.go
+++ b/internal/chart/providers/argocd/degraded.go
@@ -35,6 +35,14 @@ func degradedFailAfter() time.Duration {
 // isolated sightings around a long gap (mirrors fatalManifestMinChecks).
 const degradedMinChecks = 10
 
+// degradedRecheckInterval throttles how often a candidate that keeps failing
+// the caller's terminal check is re-reported. Each report triggers a full pod
+// diagnosis (pod list + a log stream per failing container + an events list);
+// at the 2s poll cadence an app that stays Degraded-but-recovering would
+// otherwise be re-diagnosed ~1800 times over the remaining hour, degrading the
+// wait loop's own cadence.
+const degradedRecheckInterval = time.Minute
+
 // degradedTracker records, per application, how long it has stayed Degraded+
 // Synced. Reset on change, forget on disappearance — an app that recovers or
 // goes back to Progressing starts its clock fresh.
@@ -44,8 +52,9 @@ type degradedTracker struct {
 }
 
 type degradedEntry struct {
-	since  time.Time
-	checks int
+	since        time.Time
+	checks       int
+	lastReported time.Time // when the app was last returned as a candidate
 }
 
 func newDegradedTracker() *degradedTracker {
@@ -68,10 +77,12 @@ func (t *degradedTracker) observe(apps []Application, now time.Time) []Applicati
 			e = degradedEntry{since: now}
 		}
 		e.checks++
-		t.entries[app.Name] = e
-		if e.checks >= degradedMinChecks && now.Sub(e.since) >= t.after {
+		if e.checks >= degradedMinChecks && now.Sub(e.since) >= t.after &&
+			(e.lastReported.IsZero() || now.Sub(e.lastReported) >= degradedRecheckInterval) {
+			e.lastReported = now
 			out = append(out, app)
 		}
+		t.entries[app.Name] = e
 	}
 	for name := range t.entries {
 		if !seen[name] {

--- a/internal/chart/providers/argocd/degraded.go
+++ b/internal/chart/providers/argocd/degraded.go
@@ -98,5 +98,7 @@ func degradedAppError(apps []Application, diag string) error {
 	b.WriteString("This is terminal — retrying or waiting cannot fix it.\n")
 	fmt.Fprintf(&b, "Inspect: kubectl get pods -n %s   (and: kubectl describe application %s -n argocd)",
 		apps[0].Namespace, apps[0].Name)
-	return fmt.Errorf("%s", b.String())
+	// selfDiagnosedError: the message embeds pod logs/events; the generic
+	// handler must not pattern-match them into a bogus "cluster unreachable" hint.
+	return selfDiagnosedError(b.String())
 }

--- a/internal/chart/providers/argocd/degraded_test.go
+++ b/internal/chart/providers/argocd/degraded_test.go
@@ -165,3 +165,33 @@ func TestDiagnosticErrors_AreSelfDiagnosed(t *testing.T) {
 }
 
 func errorsAs(err error, target any) bool { return stderrors.As(err, target) }
+
+// Once past its thresholds, a candidate must be re-reported at the recheck
+// interval, not on every 2s tick: each report triggers a full pod diagnosis
+// (pod list + log streams + events), ~1800 rounds an hour otherwise.
+func TestDegradedTracker_ThrottlesRecheck(t *testing.T) {
+	tr := &degradedTracker{entries: map[string]degradedEntry{}, after: time.Minute}
+	base := time.Unix(5000, 0)
+	app := []Application{degApp("x", ArgoCDHealthDegraded, ArgoCDSyncSynced)}
+
+	// Drive past both thresholds at a 2s cadence and count the reports.
+	fired := 0
+	var lastFire time.Time
+	var prevFire time.Time
+	for i := 0; i < 400; i++ { // ~13 minutes of ticks
+		now := base.Add(time.Duration(i) * 2 * time.Second)
+		if out := tr.observe(app, now); len(out) > 0 {
+			fired++
+			prevFire, lastFire = lastFire, now
+		}
+	}
+	if fired == 0 {
+		t.Fatal("a persistently Degraded app must still be reported")
+	}
+	if fired > 15 {
+		t.Fatalf("reports must be throttled to ~1/min, got %d in ~13m", fired)
+	}
+	if !prevFire.IsZero() && lastFire.Sub(prevFire) < degradedRecheckInterval {
+		t.Fatalf("consecutive reports %v apart, want >= %v", lastFire.Sub(prevFire), degradedRecheckInterval)
+	}
+}

--- a/internal/chart/providers/argocd/degraded_test.go
+++ b/internal/chart/providers/argocd/degraded_test.go
@@ -1,6 +1,7 @@
 package argocd
 
 import (
+	stderrors "errors"
 	"strings"
 	"testing"
 	"time"
@@ -136,3 +137,31 @@ func TestIsImagePullReason(t *testing.T) {
 		t.Error("CrashLoopBackOff is not an image-pull reason")
 	}
 }
+
+// Both diagnostic-carrying errors must be marked SelfDiagnosed so the generic
+// handler suppresses its pattern-matched hint (which misfires on embedded pod
+// logs like "connect: connection refused").
+func TestDiagnosticErrors_AreSelfDiagnosed(t *testing.T) {
+	type selfDiagnosed interface{ SelfDiagnosed() bool }
+
+	dErr := degradedAppError([]Application{{Name: "tenant", Namespace: "tenant"}}, "\n  pod x: CrashLoopBackOff")
+	var sd selfDiagnosed
+	if !errorsAs(dErr, &sd) || !sd.SelfDiagnosed() {
+		t.Fatal("degradedAppError must be SelfDiagnosed")
+	}
+
+	tErr := timeoutError(time.Minute, 1, 2, []string{"a"}, []string{"a"}, []string{"  - a: health=Degraded"})
+	sd = nil
+	if !errorsAs(tErr, &sd) || !sd.SelfDiagnosed() {
+		t.Fatal("timeoutError WITH diagnostics must be SelfDiagnosed")
+	}
+
+	// Without diagnostics the timeout error stays plain — generic hints stay useful.
+	plain := timeoutError(time.Minute, 1, 2, []string{"a"}, []string{"a"}, nil)
+	sd = nil
+	if errorsAs(plain, &sd) {
+		t.Fatal("timeoutError WITHOUT diagnostics must stay a plain error")
+	}
+}
+
+func errorsAs(err error, target any) bool { return stderrors.As(err, target) }

--- a/internal/chart/providers/argocd/diagnosederror.go
+++ b/internal/chart/providers/argocd/diagnosederror.go
@@ -1,0 +1,21 @@
+package argocd
+
+// diagnosedError is an error whose message already embeds its own root-cause
+// diagnosis (pod crash logs, warning events, per-app health messages). The
+// generic error handler recognizes it via the SelfDiagnosed method (matched
+// structurally by internal/shared/errors) and suppresses its pattern-matched
+// "friendly hint": matching on the embedded diagnostics misfires — a pod log
+// line like "connect: connection refused" made the handler claim the CLUSTER
+// was unreachable while it was serving the very diagnostics being printed.
+type diagnosedError struct {
+	msg string
+}
+
+func (e *diagnosedError) Error() string       { return e.msg }
+func (e *diagnosedError) SelfDiagnosed() bool { return true }
+
+// selfDiagnosedError wraps a fully-built diagnostic message as an error that
+// the generic handler will not decorate with a misfiring hint.
+func selfDiagnosedError(msg string) error {
+	return &diagnosedError{msg: msg}
+}

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -160,6 +160,13 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	if timeout <= 0 {
 		timeout = defaultAppWaitTimeout()
 	}
+	// Cap the budget to the caller's context deadline, with margin: the install
+	// path runs the WHOLE flow (ArgoCD install, clone, app-of-apps, this wait)
+	// under one 60m deadline, and this wait's own default is also 60m measured
+	// from a strictly later point — so the outer deadline always expired first
+	// and the diagnostic timeoutError below (not-ready apps, per-app health)
+	// was unreachable; users got a bare "context deadline exceeded".
+	timeout = capToDeadline(localCtx, timeout, startTime)
 	checkInterval := 2 * time.Second
 	lastCheck := time.Now()
 	clusterHealthCheckInterval := 10 * time.Second
@@ -415,14 +422,16 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 			// workload is never cut off. The error carries the pod's crash logs and
 			// events, so it says WHY, not just that it hung.
 			if cand := degraded.observe(apps, now); len(cand) > 0 {
-				if diag, terminal := m.diagnoseFailingApps(localCtx, cand); terminal {
+				if diag, stuck := m.diagnoseFailingApps(localCtx, cand); len(stuck) > 0 {
 					spinnerMutex.Lock()
 					if !spinnerStopped && spinner != nil {
 						spinner.Fail("An application is Degraded with a workload that will not recover")
 						spinnerStopped = true
 					}
 					spinnerMutex.Unlock()
-					return degradedAppError(cand, diag)
+					// Only the apps whose OWN pods are terminally stuck — not
+					// every candidate that happens to share their namespace.
+					return degradedAppError(stuck, diag)
 				}
 			}
 
@@ -919,6 +928,27 @@ func timeoutError(timeout time.Duration, ready, total int, notReadyLabels, notRe
 		return selfDiagnosedError(b.String())
 	}
 	return fmt.Errorf("%s", b.String())
+}
+
+// capToDeadline shrinks a wait budget so it elapses BEFORE the context
+// deadline, leaving a margin to gather and render the timeout diagnostic.
+// Returns the configured budget unchanged when the context has no deadline or
+// the deadline is farther away. A (nearly) exhausted deadline yields 0 — the
+// wait times out on its first tick rather than riding into ctx.Err().
+func capToDeadline(ctx context.Context, configured time.Duration, from time.Time) time.Duration {
+	const margin = time.Minute
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return configured
+	}
+	remaining := dl.Sub(from) - margin
+	if remaining < 0 {
+		return 0
+	}
+	if remaining < configured {
+		return remaining
+	}
+	return configured
 }
 
 // defaultAppWaitTimeout is the install/bootstrap application-wait budget: 60m,

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -913,6 +913,11 @@ func timeoutError(timeout time.Duration, ready, total int, notReadyLabels, notRe
 	if len(notReadyNames) > 0 {
 		fmt.Fprintf(&b, "\nDetails for one: kubectl describe application %s -n argocd", notReadyNames[0])
 	}
+	if len(notReadyDetails) > 0 {
+		// The per-app health messages above ARE the diagnosis; suppress the
+		// generic handler's pattern-matched hint (it misfires on their content).
+		return selfDiagnosedError(b.String())
+	}
 	return fmt.Errorf("%s", b.String())
 }
 

--- a/internal/chart/providers/argocd/wait_budget_test.go
+++ b/internal/chart/providers/argocd/wait_budget_test.go
@@ -1,0 +1,47 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The wait's own budget must elapse BEFORE the caller's context deadline, or
+// the diagnostic timeoutError (not-ready apps, per-app health) is unreachable
+// and the user gets a bare "context deadline exceeded". The install path runs
+// the whole flow under one 60m deadline while the wait default is also 60m
+// measured from a later point — exactly that dead zone.
+func TestCapToDeadline(t *testing.T) {
+	from := time.Now()
+
+	t.Run("no deadline keeps the configured budget", func(t *testing.T) {
+		if got := capToDeadline(context.Background(), time.Hour, from); got != time.Hour {
+			t.Fatalf("got %v, want 1h", got)
+		}
+	})
+
+	t.Run("nearer deadline caps the budget with margin", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), from.Add(30*time.Minute))
+		defer cancel()
+		got := capToDeadline(ctx, time.Hour, from)
+		if got <= 0 || got >= 30*time.Minute {
+			t.Fatalf("got %v, want (0, 30m) — deadline minus margin", got)
+		}
+	})
+
+	t.Run("farther deadline leaves the budget alone", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), from.Add(2*time.Hour))
+		defer cancel()
+		if got := capToDeadline(ctx, time.Hour, from); got != time.Hour {
+			t.Fatalf("got %v, want 1h", got)
+		}
+	})
+
+	t.Run("exhausted deadline yields zero, not negative", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), from.Add(10*time.Second))
+		defer cancel()
+		if got := capToDeadline(ctx, time.Hour, from); got != 0 {
+			t.Fatalf("got %v, want 0", got)
+		}
+	})
+}

--- a/internal/chart/providers/argocd/workloaddiag.go
+++ b/internal/chart/providers/argocd/workloaddiag.go
@@ -88,15 +88,41 @@ func failingContainers(p corev1.Pod) []containerIssue {
 	return issues
 }
 
+// appPods lists the pods belonging to an ArgoCD application: first by ArgoCD's
+// default tracking label, then by its configurable alternative. owned reports
+// whether the returned pods are attributable to the app; when neither selector
+// matches anything, it falls back to the whole namespace — still useful for
+// the human diagnostic, but NOT safe to base a fail-fast decision on: an
+// app-of-apps platform routinely shares destination namespaces, so a leftover
+// CrashLooping pod of a neighbouring app must not abort THIS app's install.
+func (m *Manager) appPods(ctx context.Context, ns, appName string) (pods []corev1.Pod, owned bool) {
+	for _, sel := range []string{"app.kubernetes.io/instance=" + appName, "argocd.argoproj.io/instance=" + appName} {
+		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		list, err := m.kubeClient.CoreV1().Pods(ns).List(listCtx, metav1.ListOptions{LabelSelector: sel})
+		cancel()
+		if err == nil && len(list.Items) > 0 {
+			return list.Items, true
+		}
+	}
+	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	list, err := m.kubeClient.CoreV1().Pods(ns).List(listCtx, metav1.ListOptions{})
+	if err != nil {
+		return nil, false
+	}
+	return list.Items, false
+}
+
 // diagnoseFailingApps inspects the workloads of the given apps and returns a
 // human diagnostic — the failing pod/container, why (waiting reason or crash), a
 // registry-auth hint for image-pull failures, the crashed container's last log
-// lines, and recent warning events. terminal is true when any workload is in a
-// won't-recover state (CrashLoop / ImagePull / repeated crashes), letting the
-// caller fail fast instead of waiting out the timeout. Best-effort throughout.
-func (m *Manager) diagnoseFailingApps(ctx context.Context, apps []Application) (diag string, terminal bool) {
+// lines, and recent warning events. stuck lists the apps whose OWN workloads
+// are in a won't-recover state (CrashLoop / ImagePull / repeated crashes),
+// letting the caller fail fast instead of waiting out the timeout — and only
+// for those apps, not every candidate sharing the namespace. Best-effort.
+func (m *Manager) diagnoseFailingApps(ctx context.Context, apps []Application) (diag string, stuck []Application) {
 	if m.kubeClient == nil {
-		return "", false
+		return "", nil
 	}
 	var b strings.Builder
 	for _, app := range apps {
@@ -104,12 +130,7 @@ func (m *Manager) diagnoseFailingApps(ctx context.Context, apps []Application) (
 		if ns == "" {
 			continue
 		}
-		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		pods, err := m.kubeClient.CoreV1().Pods(ns).List(listCtx, metav1.ListOptions{})
-		cancel()
-		if err != nil {
-			continue
-		}
+		pods, owned := m.appPods(ctx, ns, app.Name)
 		header := false
 		writeHeader := func() {
 			if !header {
@@ -117,10 +138,11 @@ func (m *Manager) diagnoseFailingApps(ctx context.Context, apps []Application) (
 				header = true
 			}
 		}
-		for i := range pods.Items {
-			for _, ci := range failingContainers(pods.Items[i]) {
+		appTerminal := false
+		for i := range pods {
+			for _, ci := range failingContainers(pods[i]) {
 				if ci.terminal {
-					terminal = true
+					appTerminal = true
 				}
 				writeHeader()
 				fmt.Fprintf(&b, "\n  pod %s / %s: %s (restarts=%d)", ci.pod, ci.container, ci.reason, ci.restarts)
@@ -143,8 +165,13 @@ func (m *Manager) diagnoseFailingApps(ctx context.Context, apps []Application) (
 			writeHeader()
 			fmt.Fprintf(&b, "\n  recent warning events:\n%s", indentLines(ev, "    "))
 		}
+		// Only attributable failures may abort: a terminal pod found via the
+		// namespace fallback could belong to any app (or to nothing at all).
+		if appTerminal && owned {
+			stuck = append(stuck, app)
+		}
 	}
-	return b.String(), terminal
+	return b.String(), stuck
 }
 
 // lastPodLogs returns the last few log lines of a container — the PREVIOUS

--- a/internal/chart/providers/argocd/workloaddiag_owned_test.go
+++ b/internal/chart/providers/argocd/workloaddiag_owned_test.go
@@ -1,0 +1,76 @@
+package argocd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func labeledCrashPod(name, ns, instance string) *corev1.Pod {
+	p := waitingPod(name, "main", "CrashLoopBackOff", "img", 5)
+	p.Namespace = ns
+	if instance != "" {
+		p.Labels = map[string]string{"app.kubernetes.io/instance": instance}
+	}
+	return &p
+}
+
+func labeledHealthyPod(name, ns, instance string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: ns,
+		Labels: map[string]string{"app.kubernetes.io/instance": instance},
+	}}
+}
+
+// A leftover CrashLooping pod of a NEIGHBOURING app in the shared namespace
+// must not mark THIS app as terminally stuck — shared destination namespaces
+// are the norm for an app-of-apps platform, and this false positive aborted a
+// whole install with "retrying or waiting cannot fix it".
+func TestDiagnoseFailingApps_NeighbourPodDoesNotAbort(t *testing.T) {
+	m := &Manager{kubeClient: fake.NewSimpleClientset(
+		labeledHealthyPod("tenant-api", "tenant", "tenant"),
+		labeledCrashPod("old-migration", "tenant", "other-app"),
+	)}
+	diag, stuck := m.diagnoseFailingApps(context.Background(),
+		[]Application{{Name: "tenant", Namespace: "tenant"}})
+	if len(stuck) != 0 {
+		t.Fatalf("a neighbour's terminal pod must not mark the app stuck, got %v", stuck)
+	}
+	_ = diag // the diagnostic text itself may mention whatever it saw
+}
+
+// An app whose OWN (instance-labeled) pod is terminally stuck is reported.
+func TestDiagnoseFailingApps_OwnTerminalPodAborts(t *testing.T) {
+	m := &Manager{kubeClient: fake.NewSimpleClientset(
+		labeledCrashPod("tenant-stream", "tenant", "tenant"),
+	)}
+	diag, stuck := m.diagnoseFailingApps(context.Background(),
+		[]Application{{Name: "tenant", Namespace: "tenant"}})
+	if len(stuck) != 1 || stuck[0].Name != "tenant" {
+		t.Fatalf("the app's own terminal pod must mark it stuck, got %v", stuck)
+	}
+	if !strings.Contains(diag, "CrashLoopBackOff") {
+		t.Fatalf("diagnostic must name the failure, got:\n%s", diag)
+	}
+}
+
+// Unlabeled workloads (no tracking labels at all) fall back to the namespace
+// listing for the human diagnostic, but never drive a fail-fast: the failure
+// cannot be attributed to the candidate app.
+func TestDiagnoseFailingApps_UnattributableIsDiagnosedButNotStuck(t *testing.T) {
+	m := &Manager{kubeClient: fake.NewSimpleClientset(
+		labeledCrashPod("mystery-pod", "tenant", ""),
+	)}
+	diag, stuck := m.diagnoseFailingApps(context.Background(),
+		[]Application{{Name: "tenant", Namespace: "tenant"}})
+	if len(stuck) != 0 {
+		t.Fatalf("an unattributable pod must not mark the app stuck, got %v", stuck)
+	}
+	if !strings.Contains(diag, "mystery-pod") {
+		t.Fatalf("the namespace fallback must still describe the failure for humans, got:\n%s", diag)
+	}
+}

--- a/internal/chart/services/chart_service.go
+++ b/internal/chart/services/chart_service.go
@@ -277,7 +277,11 @@ func (w *InstallationWorkflow) ExecuteWithContext(parentCtx context.Context, req
 		}
 		if !w.confirmInstallationOnCluster(target) {
 			pterm.Info.Println("Installation cancelled.")
-			return fmt.Errorf("installation cancelled by user")
+			// The decline is already announced above; the sentinel keeps the
+			// non-zero exit without the cmd layer re-rendering it as a scary
+			// "❌ Operation failed" (bootstrap even wrapped it as "failed to
+			// install charts: installation cancelled by user").
+			return &sharedErrors.AlreadyHandledError{OriginalError: fmt.Errorf("installation cancelled by user")}
 		}
 	}
 

--- a/internal/chart/services/chart_service.go
+++ b/internal/chart/services/chart_service.go
@@ -104,8 +104,12 @@ func NewChartServiceDeferred(clusterAccess types.ClusterAccess, dryRun, verbose 
 // initializeHelmManager initializes the HelmManager with the given rest.Config
 // This is called after cluster selection in deferred mode
 func (cs *ChartService) initializeHelmManager(kubeConfig *rest.Config, verbose bool) error {
-	chartExec := executor.NewRealCommandExecutor(false, verbose)
-	helmManager, err := helm.NewHelmManager(chartExec, kubeConfig, verbose)
+	// Reuse the service's executor: it was constructed with the request's
+	// dry-run flag. Building a fresh executor with dryRun hardcoded to false
+	// made `app install --dry-run` (which always takes this deferred path)
+	// genuinely execute `helm repo add`/`helm repo update` — network calls and
+	// writes under HELM_*_HOME — and skip every "Would run:" line for them.
+	helmManager, err := helm.NewHelmManager(cs.executor, kubeConfig, verbose)
 	if err != nil {
 		return fmt.Errorf("failed to create HelmManager: %w", err)
 	}

--- a/internal/chart/services/installer.go
+++ b/internal/chart/services/installer.go
@@ -47,7 +47,10 @@ func (i *Installer) InstallChartsWithContext(ctx context.Context, config config.
 			if stderrors.As(err, &ce) && ce.Operation == "waiting" && ce.Component == "ArgoCD applications" {
 				cause = ce.Cause
 			}
-			return errors.NewChartError("waiting", "ArgoCD applications", cause).WithCluster(config.ClusterName)
+			// WithNonRetryable, not just default-false: the wait diagnostics
+			// embed pod logs whose text ("connection refused", "i/o timeout")
+			// would otherwise pattern-match the retry policy's transient table.
+			return errors.NewChartError("waiting", "ArgoCD applications", cause).WithCluster(config.ClusterName).WithNonRetryable()
 		}
 	}
 

--- a/internal/chart/services/installer.go
+++ b/internal/chart/services/installer.go
@@ -38,8 +38,16 @@ func (i *Installer) InstallChartsWithContext(ctx context.Context, config config.
 		// Note: This is NOT a recoverable error - ArgoCD and app-of-apps are already installed,
 		// so retrying would reinstall them unnecessarily. WaitForApplications has its own internal retry logic.
 		if err := i.argoCDService.WaitForApplications(ctx, config); err != nil {
-			// Create a new non-recoverable error (don't use WrapAsChartError which preserves existing ChartError's Recoverable flag)
-			return errors.NewChartError("waiting", "ArgoCD applications", err).WithCluster(config.ClusterName)
+			// Create a new non-recoverable error (don't use WrapAsChartError which preserves existing ChartError's Recoverable flag).
+			// The service layer already wrapped with the same operation/component;
+			// rewrap its CAUSE, not the wrapper, or the message doubles up:
+			// "waiting failed for ArgoCD applications on cluster X: waiting failed for ..."
+			cause := err
+			var ce *errors.ChartError
+			if stderrors.As(err, &ce) && ce.Operation == "waiting" && ce.Component == "ArgoCD applications" {
+				cause = ce.Cause
+			}
+			return errors.NewChartError("waiting", "ArgoCD applications", cause).WithCluster(config.ClusterName)
 		}
 	}
 

--- a/internal/chart/services/installer_test.go
+++ b/internal/chart/services/installer_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	stderrors "errors"
+	"strings"
 	"testing"
 
 	"github.com/flamingo-stack/openframe-cli/internal/chart/models"
@@ -157,6 +158,27 @@ func TestInstaller_InstallCharts(t *testing.T) {
 			expectedError:    true,
 			expectedErrorMsg: "waiting failed for ArgoCD applications",
 		},
+		{
+			// The service layer already wraps the wait error with the same
+			// operation/component; the installer must rewrap the CAUSE, not the
+			// wrapper — otherwise the user sees the prefix twice:
+			// "waiting failed for ArgoCD applications on cluster X: waiting failed for ..."
+			name: "already-wrapped wait error is not double-prefixed",
+			config: config.ChartInstallConfig{
+				ClusterName: "test-cluster",
+				AppOfApps: &models.AppOfAppsConfig{
+					GitHubRepo: "owner/repo",
+				},
+			},
+			setupMocks: func(argoCD *MockArgoCDService, appOfApps *MockAppOfAppsService) {
+				argoCD.On("Install", mock.Anything, mock.Anything).Return(nil)
+				appOfApps.On("Install", mock.Anything, mock.Anything).Return(nil)
+				argoCD.On("WaitForApplications", mock.Anything, mock.Anything).
+					Return(errors.NewRecoverableChartError("waiting", "ArgoCD applications", assert.AnError, 0).WithCluster("test-cluster"))
+			},
+			expectedError:    true,
+			expectedErrorMsg: "waiting failed for ArgoCD applications",
+		},
 	}
 
 	for _, tt := range tests {
@@ -182,6 +204,10 @@ func TestInstaller_InstallCharts(t *testing.T) {
 				assert.Error(t, err)
 				if tt.expectedErrorMsg != "" {
 					assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+					// Never twice — the double-prefix regression reads
+					// "waiting failed for X: waiting failed for X: ...".
+					assert.Equal(t, 1, strings.Count(err.Error(), tt.expectedErrorMsg),
+						"error prefix must appear exactly once: %s", err.Error())
 				}
 			} else {
 				assert.NoError(t, err)

--- a/internal/chart/services/installer_test.go
+++ b/internal/chart/services/installer_test.go
@@ -252,6 +252,10 @@ func TestInstaller_InstallCharts_RecoverableError(t *testing.T) {
 	ok := stderrors.As(err, &chartErr)
 	assert.True(t, ok, "Expected ChartError")
 	assert.False(t, chartErr.IsRecoverable(), "Expected non-recoverable error - waiting failures should not trigger reinstallation")
+	// And EXPLICITLY non-retryable, not just unmarked: the wait diagnostics
+	// embed pod logs whose text ("connection refused") would otherwise
+	// pattern-match the retry policy's transient table and reinstall ArgoCD.
+	assert.True(t, chartErr.IsNonRetryable(), "wait failures must carry the explicit never-retry marker")
 }
 
 func TestInstaller_InstallCharts_NoWaitWithoutAppOfApps(t *testing.T) {

--- a/internal/chart/utils/errors/chart_errors.go
+++ b/internal/chart/utils/errors/chart_errors.go
@@ -14,7 +14,13 @@ type ChartError struct {
 	Cause       error
 	Timestamp   time.Time
 	Recoverable bool
-	RetryAfter  time.Duration
+	// NonRetryable is an explicit "never retry" marking — stronger than
+	// Recoverable=false (the default), which merely means "unclassified" and
+	// lets the retry policy classify the cause itself. Set it on errors whose
+	// message embeds diagnostics (pod logs, events) that could pattern-match
+	// as transient, or where a retry would redo already-completed work.
+	NonRetryable bool
+	RetryAfter   time.Duration
 }
 
 // Error reads as "<operation> failed for <component> [on cluster <name>]: <cause>",
@@ -79,6 +85,17 @@ func (e *ChartError) WithRecovery(retryAfter time.Duration) *ChartError {
 	e.Recoverable = true
 	e.RetryAfter = retryAfter
 	return e
+}
+
+// WithNonRetryable explicitly forbids retrying this error (see the field doc).
+func (e *ChartError) WithNonRetryable() *ChartError {
+	e.NonRetryable = true
+	return e
+}
+
+// IsNonRetryable implements the shared errors.NonRetryableError marker.
+func (e *ChartError) IsNonRetryable() bool {
+	return e.NonRetryable
 }
 
 // Chart Error Types

--- a/internal/cluster/providers/eks/provider.go
+++ b/internal/cluster/providers/eks/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/pterm/pterm"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -164,12 +165,12 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 
 	ws := p.registry.Workspace(config.Name)
 	freshWorkspace := !ws.Exists()
+	vars, err := tfvarsFor(config)
+	if err != nil {
+		return nil, err
+	}
 	if freshWorkspace {
 		if err := p.preflightNameCollision(ctx, config); err != nil {
-			return nil, err
-		}
-		vars, err := tfvarsFor(config)
-		if err != nil {
 			return nil, err
 		}
 		record := tfengine.Record{
@@ -190,20 +191,19 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 				return nil, err
 			}
 		}
+	} else if backend != nil {
+		// Repointing an existing workspace's state backend needs a terraform
+		// state migration this CLI does not drive. Dropping the flag silently
+		// would leave the user believing their state moved — say it out loud.
+		pterm.Warning.Println("--backend-config is ignored when resuming an existing workspace; the backend chosen at first create stays in effect")
 	}
 	// An existing workspace means a previous create failed or was interrupted.
 	// Refresh the generated module from the CURRENT template before resuming:
 	// the retry must pick up template bugfixes (e.g. the private-nodes fix for
 	// org-policy environments), not replay the broken files. The state is
 	// untouched — terraform reconciles it against the refreshed config.
-	if ws.Exists() {
-		vars, err := tfvarsFor(config)
-		if err != nil {
-			return nil, err
-		}
-		if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
-			return nil, err
-		}
+	if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
+		return nil, err
 	}
 
 	if err := p.engine.Init(ctx, ws.TerraformDir()); err != nil {
@@ -243,6 +243,12 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	if err != nil {
 		return nil, err
 	}
+	// The module applied above was regenerated from the CURRENT config; make
+	// the record agree with it, or a resumed create with changed flags (e.g.
+	// --nodes) reports the first attempt's values from list/status forever.
+	record.Region = config.Cloud.Region
+	record.NodeCount = config.NodeCount
+	record.K8sVersion = vars.KubernetesVersion
 	if record.Endpoint, err = tfengine.StringOutput(outputs, "cluster_endpoint"); err != nil {
 		return nil, models.NewClusterOperationError("create", config.Name, err)
 	}
@@ -370,7 +376,7 @@ func infoFor(rec tfengine.Record) models.ClusterInfo {
 		Source:     models.SourceOpenframe,
 		Context:    rec.Name,
 		Region:     rec.Region,
-		Status:     strings.ToTitle(string(rec.Status[0:1])) + string(rec.Status[1:]),
+		Status:     rec.Status.Title(),
 		NodeCount:  rec.NodeCount,
 		K8sVersion: rec.K8sVersion,
 		CreatedAt:  rec.CreatedAt,

--- a/internal/cluster/providers/eks/template.go
+++ b/internal/cluster/providers/eks/template.go
@@ -52,11 +52,27 @@ func tfvarsFor(config models.ClusterConfig) (tfvars, error) {
 		KubernetesVersion: version,
 		InstanceType:      cloud.MachineType,
 		MinNodes:          cloud.MinNodes,
-		MaxNodes:          cloud.MaxNodes,
+		MaxNodes:          effectiveMaxNodes(cloud.MaxNodes, config.NodeCount),
 		DesiredNodes:      config.NodeCount,
 		Spot:              cloud.Spot,
 	}
 	return vars, nil
+}
+
+// templateDefaultMaxNodes mirrors the max_nodes default in templates/main.tf.
+const templateDefaultMaxNodes = 4
+
+// effectiveMaxNodes keeps `--nodes` authoritative when --max-nodes is not
+// given: with max omitted from tfvars the template default (4) applies, and a
+// `--nodes 6` create would ask for a node group whose desired size exceeds its
+// own maximum — rejected mid-apply, or silently scaled down, contradicting the
+// flag. An unset max grows to cover the requested count; an explicit max is
+// validated against it instead (validate).
+func effectiveMaxNodes(maxNodes, nodeCount int) int {
+	if maxNodes == 0 && nodeCount > templateDefaultMaxNodes {
+		return nodeCount
+	}
+	return maxNodes
 }
 
 // validate enforces the EKS-specific config invariants at the domain boundary.
@@ -79,6 +95,15 @@ func validate(config models.ClusterConfig) error {
 	}
 	if c.MinNodes > 0 && c.MaxNodes > 0 && c.MinNodes > c.MaxNodes {
 		return models.NewInvalidConfigError("nodes", fmt.Sprintf("min=%d max=%d", c.MinNodes, c.MaxNodes), "min nodes must not exceed max nodes")
+	}
+	// The desired count must sit inside the scaling bounds, or the node group
+	// is rejected mid-apply — after the VPC and control plane are already
+	// created and billed.
+	if c.MaxNodes > 0 && config.NodeCount > c.MaxNodes {
+		return models.NewInvalidConfigError("nodes", fmt.Sprintf("nodes=%d max=%d", config.NodeCount, c.MaxNodes), "node count must not exceed max nodes")
+	}
+	if c.MinNodes > 0 && config.NodeCount < c.MinNodes {
+		return models.NewInvalidConfigError("nodes", fmt.Sprintf("nodes=%d min=%d", config.NodeCount, c.MinNodes), "node count must not be below min nodes")
 	}
 	return nil
 }

--- a/internal/cluster/providers/eks/template_bounds_test.go
+++ b/internal/cluster/providers/eks/template_bounds_test.go
@@ -1,0 +1,52 @@
+package eks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --nodes outside the scaling bounds must fail validation up front — not
+// mid-apply, after the VPC and control plane are already created and billed.
+func TestValidate_NodeCountWithinScalingBounds(t *testing.T) {
+	cfg := eksConfig("demo")
+	cfg.NodeCount = 6
+	cfg.Cloud.MaxNodes = 4
+	err := validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not exceed max nodes")
+
+	cfg = eksConfig("demo")
+	cfg.NodeCount = 2
+	cfg.Cloud.MinNodes = 3
+	err = validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be below min nodes")
+
+	cfg = eksConfig("demo")
+	cfg.NodeCount = 3
+	cfg.Cloud.MinNodes = 1
+	cfg.Cloud.MaxNodes = 5
+	require.NoError(t, validate(cfg))
+}
+
+// With --max-nodes omitted, the template default (4) must not silently cap a
+// larger --nodes: the derived max grows to cover the requested count.
+func TestTfvarsFor_DerivesMaxNodesFromNodeCount(t *testing.T) {
+	cfg := eksConfig("demo")
+	cfg.NodeCount = 6
+	vars, err := tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 6, vars.MaxNodes, "unset max must grow to cover --nodes")
+
+	cfg.NodeCount = 3
+	vars, err = tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, vars.MaxNodes)
+
+	cfg.Cloud.MaxNodes = 8
+	vars, err = tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 8, vars.MaxNodes)
+}

--- a/internal/cluster/providers/gke/provider.go
+++ b/internal/cluster/providers/gke/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	tfengine "github.com/flamingo-stack/openframe-cli/internal/cluster/providers/terraform"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/executor"
+	"github.com/pterm/pterm"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -243,14 +244,14 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 
 	ws := p.registry.Workspace(config.Name)
 	freshWorkspace := !ws.Exists()
+	vars, err := tfvarsFor(config)
+	if err != nil {
+		return nil, err
+	}
 	// The collision check only guards NEW clusters: an existing workspace means
 	// the cloud cluster (partial or complete) is ours and create resumes it.
 	if freshWorkspace {
 		if err := p.preflightNameCollision(ctx, config); err != nil {
-			return nil, err
-		}
-		vars, err := tfvarsFor(config)
-		if err != nil {
 			return nil, err
 		}
 		record := tfengine.Record{
@@ -271,20 +272,19 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 				return nil, err
 			}
 		}
+	} else if backend != nil {
+		// Repointing an existing workspace's state backend needs a terraform
+		// state migration this CLI does not drive. Dropping the flag silently
+		// would leave the user believing their state moved — say it out loud.
+		pterm.Warning.Println("--backend-config is ignored when resuming an existing workspace; the backend chosen at first create stays in effect")
 	}
 	// An existing workspace means a previous create failed or was interrupted.
 	// Refresh the generated module from the CURRENT template before resuming:
 	// the retry must pick up template bugfixes (e.g. the private-nodes fix for
 	// org-policy environments), not replay the broken files. The state is
 	// untouched — terraform reconciles it against the refreshed config.
-	if ws.Exists() {
-		vars, err := tfvarsFor(config)
-		if err != nil {
-			return nil, err
-		}
-		if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
-			return nil, err
-		}
+	if err := tfengine.WriteModule(ws.TerraformDir(), mainTF, vars); err != nil {
+		return nil, err
 	}
 
 	if err := p.engine.Init(ctx, ws.TerraformDir()); err != nil {
@@ -333,6 +333,12 @@ func (p *Provider) CreateCluster(ctx context.Context, config models.ClusterConfi
 	if err != nil {
 		return nil, err
 	}
+	// The module applied above was regenerated from the CURRENT config; make
+	// the record agree with it, or a resumed create with changed flags (e.g.
+	// --nodes) reports the first attempt's values from list/status forever.
+	record.Region = config.Cloud.Region
+	record.NodeCount = config.NodeCount
+	record.K8sVersion = vars.KubernetesVersion
 	endpoint, err := tfengine.StringOutput(outputs, "cluster_endpoint")
 	if err != nil {
 		return nil, models.NewClusterOperationError("create", config.Name, err)
@@ -386,7 +392,7 @@ func (p *Provider) DeleteCluster(ctx context.Context, name string, clusterType m
 		// Sweep any PVC-provisioned disks that outlived the destroy: delete them
 		// when the caller consented to an unattended teardown (--force), else
 		// report them — a "cleaned up" delete must never silently leave orphans.
-		p.sweepOrphanedDisks(ctx, rec.Project, name, force)
+		p.sweepOrphanedDisks(ctx, rec.Project, name, rec.Region, force)
 	}
 	return ws.Remove()
 }
@@ -477,7 +483,7 @@ func infoFor(rec tfengine.Record) models.ClusterInfo {
 		Context:    rec.Name,
 		Project:    rec.Project,
 		Region:     rec.Region,
-		Status:     strings.ToTitle(string(rec.Status[0:1])) + string(rec.Status[1:]),
+		Status:     rec.Status.Title(),
 		NodeCount:  rec.NodeCount,
 		K8sVersion: rec.K8sVersion,
 		CreatedAt:  rec.CreatedAt,

--- a/internal/cluster/providers/gke/provider_test.go
+++ b/internal/cluster/providers/gke/provider_test.go
@@ -507,3 +507,28 @@ func TestCreateCluster_DeclinedResumeKeepsWorkspace(t *testing.T) {
 	_, err = registry.Get("demo")
 	require.NoError(t, err, "declined resume must keep the workspace and its state")
 }
+
+// Resuming an interrupted create with changed flags must leave the registry
+// record agreeing with what was actually applied — not the first attempt's
+// values, reported by list/status forever.
+func TestCreateCluster_ResumeRefreshesRecord(t *testing.T) {
+	p, _, registry := newTestProvider(t, errors.New("quota exceeded"))
+	cfg := gkeConfig("demo")
+	_, err := p.CreateCluster(context.Background(), cfg)
+	require.Error(t, err)
+
+	// Resume with a different node count on a working engine over the SAME registry.
+	calls := &[]string{}
+	engine := tfengine.NewEngineWithRunner(func(string) (tfengine.Runner, error) {
+		return &fakeRunner{calls: calls}, nil
+	})
+	p2 := NewWithDeps(engine, registry, executor.NewMockCommandExecutor())
+	cfg.NodeCount = 6
+	_, err = p2.CreateCluster(context.Background(), cfg)
+	require.NoError(t, err)
+
+	rec, err := registry.Get("demo")
+	require.NoError(t, err)
+	assert.Equal(t, 6, rec.NodeCount, "resume must refresh the record to the flags it actually applied")
+	assert.Equal(t, tfengine.StatusReady, rec.Status)
+}

--- a/internal/cluster/providers/gke/teardown.go
+++ b/internal/cluster/providers/gke/teardown.go
@@ -161,8 +161,39 @@ func releaseWorkloadDisks(ctx context.Context, rec tfengine.Record) {
 
 // disk is one labeled Persistent Disk found by the post-destroy sweep.
 type disk struct {
-	name string
-	zone string // basename, e.g. "us-central1-a"; empty for a regional disk
+	name   string
+	zone   string // basename, e.g. "us-central1-a"; empty for a regional disk
+	region string // basename, e.g. "us-central1"; set for regional disks only
+}
+
+// location returns where the disk lives: its zone, or its region for a
+// regional disk.
+func (d disk) location() string {
+	if d.zone != "" {
+		return d.zone
+	}
+	return d.region
+}
+
+// disksInLocation keeps only disks that can belong to the deleted cluster.
+// GKE cluster names are unique per LOCATION, not per project, so the
+// name-label filter alone would also match — and with --force delete — the
+// still-attached disks of a same-named, live cluster in another region. The
+// record stores the cluster's region; a zonal disk of that cluster lives in
+// "<region>-<suffix>". An empty location (a record predating this field)
+// keeps everything, degrading to the unscoped behavior.
+func disksInLocation(disks []disk, location string) []disk {
+	if location == "" {
+		return disks
+	}
+	var out []disk
+	for _, d := range disks {
+		loc := d.location()
+		if loc == location || strings.HasPrefix(loc, location+"-") {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 // sweepOrphanedDisks finds Persistent Disks still labeled for this cluster after
@@ -171,18 +202,18 @@ type disk struct {
 // via --force, or an interactive yes to the prompt — so the cluster leaves zero
 // billable leftovers; otherwise it reports them with the exact cleanup command
 // and never deletes cloud data without consent. Best-effort throughout.
-func (p *Provider) sweepOrphanedDisks(ctx context.Context, project, name string, force bool) {
+func (p *Provider) sweepOrphanedDisks(ctx context.Context, project, name, location string, force bool) {
 	if project == "" {
 		return
 	}
 	res, err := p.executor.Execute(ctx, "gcloud", "compute", "disks", "list",
 		"--project", project,
 		"--filter", "labels.goog-k8s-cluster-name="+name,
-		"--format=value(name,zone.basename())")
+		"--format=value(name,zone.basename(),region.basename())")
 	if err != nil || res == nil {
 		return
 	}
-	disks := parseDisks(res.Stdout)
+	disks := disksInLocation(parseDisks(res.Stdout), location)
 	if len(disks) == 0 {
 		return
 	}
@@ -229,7 +260,13 @@ func (p *Provider) sweepOrphanedDisks(ctx context.Context, project, name string,
 func printOrphanList(disks []disk, name string) {
 	pterm.Warning.Printf("%d Persistent Disk(s) labeled for cluster %q survived the destroy (PVC-provisioned, outside terraform state):\n", len(disks), name)
 	for _, d := range disks {
-		pterm.Warning.Printf("  - %s\n", d.name)
+		// The location tells the operator WHICH cluster's disks these are —
+		// GKE cluster names repeat across locations.
+		if loc := d.location(); loc != "" {
+			pterm.Warning.Printf("  - %s (%s)\n", d.name, loc)
+		} else {
+			pterm.Warning.Printf("  - %s\n", d.name)
+		}
 	}
 }
 
@@ -241,18 +278,23 @@ func printOrphanCleanupHint(project, name string) {
 }
 
 // parseDisks turns `gcloud compute disks list
-// --format=value(name,zone.basename())` output into disks — one per non-empty
-// line, fields separated by whitespace (name, then optional zone).
+// --format=value(name,zone.basename(),region.basename())` output into disks —
+// one per non-empty line. value() output is TAB-separated with empty columns
+// kept: a regional disk has an empty zone column, so a whitespace split would
+// shift its region into the zone slot.
 func parseDisks(out string) []disk {
 	var disks []disk
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		fields := strings.Fields(line)
-		d := disk{name: fields[0]}
+		fields := strings.Split(line, "\t")
+		d := disk{name: strings.TrimSpace(fields[0])}
 		if len(fields) > 1 {
-			d.zone = fields[1]
+			d.zone = strings.TrimSpace(fields[1])
+		}
+		if len(fields) > 2 {
+			d.region = strings.TrimSpace(fields[2])
 		}
 		disks = append(disks, d)
 	}

--- a/internal/cluster/providers/gke/teardown_test.go
+++ b/internal/cluster/providers/gke/teardown_test.go
@@ -57,19 +57,45 @@ func TestCountDeletablePVs(t *testing.T) {
 }
 
 func TestParseDisks(t *testing.T) {
-	out := "pvc-abc\tus-central1-a\npvc-def\tus-central1-b\nregional-disk\n\n"
+	// value() output is TAB-separated with empty columns kept: a regional disk
+	// has an empty zone column before its region.
+	out := "pvc-abc\tus-central1-a\t\npvc-def\tus-central1-b\t\nregional-disk\t\tus-central1\n\n"
 	got := parseDisks(out)
 	if len(got) != 3 {
 		t.Fatalf("parseDisks returned %d, want 3: %+v", len(got), got)
 	}
-	if got[0].name != "pvc-abc" || got[0].zone != "us-central1-a" {
+	if got[0].name != "pvc-abc" || got[0].zone != "us-central1-a" || got[0].region != "" {
 		t.Fatalf("first disk = %+v", got[0])
 	}
-	if got[2].name != "regional-disk" || got[2].zone != "" {
-		t.Fatalf("zoneless disk must parse with empty zone, got %+v", got[2])
+	if got[2].name != "regional-disk" || got[2].zone != "" || got[2].region != "us-central1" {
+		t.Fatalf("regional disk must parse with empty zone and its region, got %+v", got[2])
 	}
 	if len(parseDisks("")) != 0 {
 		t.Fatal("empty output must yield no disks")
+	}
+}
+
+// GKE cluster names are unique per LOCATION, not per project: the sweep must
+// never touch a same-named cluster's disks in another region.
+func TestDisksInLocation(t *testing.T) {
+	all := []disk{
+		{name: "mine-zonal", zone: "us-central1-a"},
+		{name: "other-zonal", zone: "europe-west1-b"},
+		{name: "mine-regional", region: "us-central1"},
+		{name: "other-regional", region: "europe-west1"},
+	}
+	got := disksInLocation(all, "us-central1")
+	if len(got) != 2 || got[0].name != "mine-zonal" || got[1].name != "mine-regional" {
+		t.Fatalf("expected only us-central1 disks, got %+v", got)
+	}
+	// A record without a location (predates the field) keeps everything.
+	if got := disksInLocation(all, ""); len(got) != 4 {
+		t.Fatalf("empty location must keep all disks, got %+v", got)
+	}
+	// A region name must not prefix-match a lookalike ("us-central12-a").
+	lookalike := []disk{{name: "x", zone: "us-central12-a"}}
+	if got := disksInLocation(lookalike, "us-central1"); len(got) != 0 {
+		t.Fatalf("us-central12-a must not match us-central1, got %+v", got)
 	}
 }
 
@@ -84,7 +110,7 @@ func TestSweepOrphanedDisks_ConsentGating(t *testing.T) {
 		mock.SetResponse("gcloud compute disks list", listResp)
 		p.executor = mock
 
-		p.sweepOrphanedDisks(context.Background(), "proj", "demo", false)
+		p.sweepOrphanedDisks(context.Background(), "proj", "demo", "us-central1", false)
 		if mock.WasCommandExecuted("gcloud compute disks delete") {
 			t.Fatal("without --force the sweep must NOT delete disks")
 		}
@@ -96,9 +122,27 @@ func TestSweepOrphanedDisks_ConsentGating(t *testing.T) {
 		mock.SetResponse("gcloud compute disks list", listResp)
 		p.executor = mock
 
-		p.sweepOrphanedDisks(context.Background(), "proj", "demo", true)
+		p.sweepOrphanedDisks(context.Background(), "proj", "demo", "us-central1", true)
 		if !mock.WasCommandExecuted("gcloud compute disks delete pvc-abc --zone us-central1-a") {
 			t.Fatalf("with --force the sweep must delete the orphan; ran: %v", mock.GetExecutedCommands())
+		}
+	})
+
+	t.Run("force: never deletes a same-named other-location cluster's disks", func(t *testing.T) {
+		p, _, _ := newTestProvider(t, nil)
+		mock := executor.NewMockCommandExecutor()
+		mock.SetResponse("gcloud compute disks list", &executor.CommandResult{
+			ExitCode: 0,
+			Stdout:   "pvc-mine\tus-central1-a\t\npvc-other\teurope-west1-b\t\n",
+		})
+		p.executor = mock
+
+		p.sweepOrphanedDisks(context.Background(), "proj", "demo", "us-central1", true)
+		if !mock.WasCommandExecuted("gcloud compute disks delete pvc-mine --zone us-central1-a") {
+			t.Fatalf("the deleted cluster's own disk must be swept; ran: %v", mock.GetExecutedCommands())
+		}
+		if mock.WasCommandExecuted("gcloud compute disks delete pvc-other") {
+			t.Fatal("a disk of the same-named cluster in another location must never be deleted")
 		}
 	})
 
@@ -106,7 +150,7 @@ func TestSweepOrphanedDisks_ConsentGating(t *testing.T) {
 		p, _, _ := newTestProvider(t, nil)
 		mock := executor.NewMockCommandExecutor()
 		p.executor = mock
-		p.sweepOrphanedDisks(context.Background(), "", "demo", true)
+		p.sweepOrphanedDisks(context.Background(), "", "demo", "us-central1", true)
 		if mock.GetCommandCount() != 0 {
 			t.Fatal("no project → no gcloud calls")
 		}

--- a/internal/cluster/providers/gke/template.go
+++ b/internal/cluster/providers/gke/template.go
@@ -57,10 +57,26 @@ func tfvarsFor(config models.ClusterConfig) (tfvars, error) {
 		KubernetesVersion: version,
 		InstanceType:      cloud.MachineType,
 		MinNodes:          cloud.MinNodes,
-		MaxNodes:          cloud.MaxNodes,
+		MaxNodes:          effectiveMaxNodes(cloud.MaxNodes, config.NodeCount),
 		DesiredNodes:      config.NodeCount,
 		Spot:              cloud.Spot,
 	}, nil
+}
+
+// templateDefaultMaxNodes mirrors the max_nodes default in templates/main.tf.
+const templateDefaultMaxNodes = 4
+
+// effectiveMaxNodes keeps `--nodes` authoritative when --max-nodes is not
+// given: with max omitted from tfvars the template default (4) applies, and a
+// `--nodes 6` create would fail mid-apply (initial node count outside the
+// autoscaler bounds) after minutes of billed infrastructure — or silently be
+// scaled down, contradicting the flag. So an unset max grows to cover the
+// requested count; an explicit max is validated against it instead (validate).
+func effectiveMaxNodes(maxNodes, nodeCount int) int {
+	if maxNodes == 0 && nodeCount > templateDefaultMaxNodes {
+		return nodeCount
+	}
+	return maxNodes
 }
 
 // validate enforces the GKE-specific config invariants at the domain boundary.
@@ -86,6 +102,15 @@ func validate(config models.ClusterConfig) error {
 	}
 	if c.MinNodes > 0 && c.MaxNodes > 0 && c.MinNodes > c.MaxNodes {
 		return models.NewInvalidConfigError("nodes", fmt.Sprintf("min=%d max=%d", c.MinNodes, c.MaxNodes), "min nodes must not exceed max nodes")
+	}
+	// The desired count must sit inside the autoscaler bounds, or the node pool
+	// is rejected mid-apply — after the VPC, NAT, and control plane are already
+	// created and billed.
+	if c.MaxNodes > 0 && config.NodeCount > c.MaxNodes {
+		return models.NewInvalidConfigError("nodes", fmt.Sprintf("nodes=%d max=%d", config.NodeCount, c.MaxNodes), "node count must not exceed max nodes")
+	}
+	if c.MinNodes > 0 && config.NodeCount < c.MinNodes {
+		return models.NewInvalidConfigError("nodes", fmt.Sprintf("nodes=%d min=%d", config.NodeCount, c.MinNodes), "node count must not be below min nodes")
 	}
 	return nil
 }

--- a/internal/cluster/providers/gke/template_bounds_test.go
+++ b/internal/cluster/providers/gke/template_bounds_test.go
@@ -1,0 +1,57 @@
+package gke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --nodes outside the autoscaler bounds must fail validation up front — not
+// mid-apply, after the VPC/NAT/control plane are already created and billed.
+func TestValidate_NodeCountWithinAutoscalerBounds(t *testing.T) {
+	cfg := gkeConfig("demo")
+	cfg.NodeCount = 6
+	cfg.Cloud.MaxNodes = 4
+	err := validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not exceed max nodes")
+
+	cfg = gkeConfig("demo")
+	cfg.NodeCount = 2
+	cfg.Cloud.MinNodes = 3
+	err = validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be below min nodes")
+
+	// Inside explicit bounds — fine.
+	cfg = gkeConfig("demo")
+	cfg.NodeCount = 3
+	cfg.Cloud.MinNodes = 1
+	cfg.Cloud.MaxNodes = 5
+	require.NoError(t, validate(cfg))
+}
+
+// With --max-nodes omitted, the template default (4) must not silently cap a
+// larger --nodes: the derived max grows to cover the requested count.
+func TestTfvarsFor_DerivesMaxNodesFromNodeCount(t *testing.T) {
+	cfg := gkeConfig("demo")
+	cfg.NodeCount = 6
+	vars, err := tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 6, vars.MaxNodes, "unset max must grow to cover --nodes")
+	assert.Equal(t, 6, vars.DesiredNodes)
+
+	// At or under the template default the max stays unset (template default applies).
+	cfg.NodeCount = 3
+	vars, err = tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, vars.MaxNodes)
+
+	// An explicit max is never overridden.
+	cfg.NodeCount = 3
+	cfg.Cloud.MaxNodes = 8
+	vars, err = tfvarsFor(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 8, vars.MaxNodes)
+}

--- a/internal/cluster/providers/terraform/workspace.go
+++ b/internal/cluster/providers/terraform/workspace.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
@@ -32,6 +33,17 @@ const (
 	StatusReady    Status = "ready"
 	StatusFailed   Status = "failed"
 )
+
+// Title renders the status capitalized for display ("ready" → "Ready"). A
+// record with a missing status degrades to "Unknown": Registry.List accepts any
+// cluster.json that unmarshals, so one hand-edited or truncated file must not
+// crash `cluster list` for every other cluster with an index-out-of-range.
+func (s Status) Title() string {
+	if s == "" {
+		return "Unknown"
+	}
+	return strings.ToUpper(string(s[:1])) + string(s[1:])
+}
 
 // Record is the persisted registry entry for one cloud cluster. Endpoint and
 // CACert are captured from terraform outputs after a successful apply so that

--- a/internal/cluster/providers/terraform/workspace_test.go
+++ b/internal/cluster/providers/terraform/workspace_test.go
@@ -93,3 +93,13 @@ func TestRegistry_GetMissingIsClusterNotFound(t *testing.T) {
 	var notFound models.ErrClusterNotFound
 	assert.ErrorAs(t, err, &notFound)
 }
+
+// A record with a missing status must render as "Unknown", not crash the whole
+// `cluster list` with an index-out-of-range: Registry.List accepts any
+// cluster.json that unmarshals, including hand-edited or truncated ones.
+func TestStatusTitle(t *testing.T) {
+	assert.Equal(t, "Ready", StatusReady.Title())
+	assert.Equal(t, "Creating", StatusCreating.Title())
+	assert.Equal(t, "Failed", StatusFailed.Title())
+	assert.Equal(t, "Unknown", Status("").Title())
+}

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -804,10 +804,11 @@ func (s *ClusterService) showNextSteps(clusterName string, clusterType models.Cl
 
 // ShowClusterStatus handles cluster status display logic
 func (s *ClusterService) ShowClusterStatus(name string, detailed bool, skipApps bool, verbose bool) error {
-	ctx := context.Background()
-
-	// Get cluster status
-	status, err := s.manager.GetClusterStatus(ctx, name)
+	// Resolve through the cluster-type-aware path (cloud registry first, then
+	// k3d), not the k3d manager directly — otherwise a recorded GKE/EKS cluster
+	// was reported "not found" here even though `--output json` (which goes
+	// through GetClusterStatus) rendered it fine.
+	status, err := s.GetClusterStatus(name)
 	if err != nil {
 		// Check if it's a "cluster not found" error and handle it friendly
 		if strings.Contains(err.Error(), "not found") {
@@ -815,8 +816,10 @@ func (s *ClusterService) ShowClusterStatus(name string, detailed bool, skipApps 
 			if isTerminalEnvironment() {
 				pterm.DefaultBasicText.Println()
 
-				// Get list of available clusters to show user their options
-				clusters, listErr := s.manager.ListClusters(ctx)
+				// Get list of available clusters to show user their options —
+				// the merged local+cloud list, so the box never claims a cloud
+				// cluster's name is unavailable while offering only k3d names.
+				clusters, listErr := s.ListClusters()
 
 				var boxContent string
 				if listErr == nil && len(clusters) > 0 {

--- a/internal/cluster/service_test.go
+++ b/internal/cluster/service_test.go
@@ -285,3 +285,33 @@ func TestShouldResumeCloudCreate(t *testing.T) {
 		}
 	}
 }
+
+// The default (text) status path must resolve through the cloud-aware lookup:
+// a registry-recorded GKE/EKS cluster used to be reported "not found" here
+// while `--output json` rendered it fine.
+func TestClusterService_ShowClusterStatus_FindsCloudCluster(t *testing.T) {
+	t.Setenv("OPENFRAME_CLUSTERS_DIR", t.TempDir())
+	service := NewClusterService(createTestExecutor())
+
+	reg := tfengine.NewRegistry(os.Getenv("OPENFRAME_CLUSTERS_DIR"))
+	record := tfengine.Record{
+		Name:      "cloudy",
+		Type:      models.ClusterTypeGKE,
+		Status:    tfengine.StatusReady,
+		Region:    "us-central1",
+		Project:   "proj",
+		NodeCount: 3,
+	}
+	if err := reg.Workspace("cloudy").Scaffold(record, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.ShowClusterStatus("cloudy", false, false, false); err != nil {
+		t.Fatalf("a registry-recorded cloud cluster must not be 'not found': %v", err)
+	}
+
+	// An unknown name still errors.
+	if err := service.ShowClusterStatus("ghost", false, false, false); err == nil {
+		t.Fatal("an unknown cluster must still report not found")
+	}
+}

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -218,6 +218,16 @@ func HandleGlobalError(err error, verbose bool) error {
 		return nil
 	}
 
+	// A sentinel anywhere in the chain means an inner layer already displayed
+	// this error (the chart workflow calls this handler itself before its
+	// result travels back through the cmd layer, which calls it again) —
+	// re-rendering printed the same failure twice. Return the error as-is so
+	// the sentinel still maps to a non-zero exit without a second print.
+	var handled *AlreadyHandledError
+	if stderrors.As(err, &handled) {
+		return err
+	}
+
 	handler := NewErrorHandler(verbose)
 
 	// Display the error (interruptions get a friendly "cancelled" message). We

--- a/internal/shared/errors/friendly.go
+++ b/internal/shared/errors/friendly.go
@@ -1,6 +1,20 @@
 package errors
 
-import "strings"
+import (
+	stderrors "errors"
+	"strings"
+)
+
+// SelfDiagnosed marks an error that already carries its own root-cause
+// diagnosis (e.g. the ArgoCD wait's stuck-app error embedding the failing
+// pod's crash logs and events). friendlyHint must stay silent for these:
+// pattern-matching the WHOLE message would otherwise misfire on the embedded
+// diagnostics — a pod log line like "dial tcp ...: connect: connection
+// refused" made the handler claim "The cluster isn't reachable" under a
+// perfectly reachable cluster (observed live in CI).
+type SelfDiagnosed interface {
+	SelfDiagnosed() bool
+}
 
 // friendlyHint returns a plain-language, actionable hint for common low-level
 // failures, or "" when none applies. It exists so non-technical users get a
@@ -8,6 +22,12 @@ import "strings"
 // underlying error — it's shown as an extra "did you mean" line.
 func friendlyHint(err error) string {
 	if err == nil {
+		return ""
+	}
+	// An error that diagnosed itself needs no generic hint — and matching on
+	// its embedded logs/events would produce a WRONG one.
+	var sd SelfDiagnosed
+	if stderrors.As(err, &sd) && sd.SelfDiagnosed() {
 		return ""
 	}
 	msg := strings.ToLower(err.Error())

--- a/internal/shared/errors/friendly_test.go
+++ b/internal/shared/errors/friendly_test.go
@@ -44,3 +44,33 @@ func TestContainsAny(t *testing.T) {
 	assert.False(t, containsAny("hello world", "nope", "zzz"))
 	assert.False(t, containsAny("hello"))
 }
+
+// selfDiagStub mimics an error that carries its own diagnosis (like the ArgoCD
+// wait's stuck-app error embedding pod crash logs).
+type selfDiagStub struct{ msg string }
+
+func (s *selfDiagStub) Error() string       { return s.msg }
+func (s *selfDiagStub) SelfDiagnosed() bool { return true }
+
+// A self-diagnosed error must get NO generic hint: its embedded pod logs
+// ("connect: connection refused" from a probe failure) previously misfired the
+// "cluster isn't reachable" hint under a perfectly reachable cluster.
+func TestFriendlyHint_SilentForSelfDiagnosed(t *testing.T) {
+	err := &selfDiagStub{msg: "2 application(s) are Degraded...\n" +
+		"  Unhealthy Pod/x: Startup probe failed: dial tcp 10.0.0.1:8096: connect: connection refused"}
+	assert.Empty(t, friendlyHint(err), "self-diagnosed errors must suppress pattern-matched hints")
+
+	// And the marker must survive wrapping (the chart/service layers wrap it).
+	wrapped := &wrapErr{cause: err}
+	assert.Empty(t, friendlyHint(wrapped), "the marker must be found through Unwrap chains")
+
+	// A plain error with the same text still gets the hint — only the marker
+	// changes behavior.
+	plain := errors.New("dial tcp 10.0.0.1:8096: connect: connection refused")
+	assert.Contains(t, friendlyHint(plain), "isn't reachable")
+}
+
+type wrapErr struct{ cause error }
+
+func (w *wrapErr) Error() string { return "waiting failed: " + w.cause.Error() }
+func (w *wrapErr) Unwrap() error { return w.cause }

--- a/internal/shared/errors/global_error_test.go
+++ b/internal/shared/errors/global_error_test.go
@@ -50,3 +50,15 @@ func TestHandleError_InterruptionDoesNotExit(t *testing.T) {
 	NewErrorHandler(false).HandleError(fmt.Errorf("interrupt"))
 	// Reaching here proves no os.Exit happened.
 }
+
+// An error already displayed by an inner layer (sentinel anywhere in the
+// chain) must pass through untouched — the chart workflow calls the handler
+// itself, and the cmd layer's second call used to print the same failure twice.
+func TestHandleGlobalError_DoesNotReprintAlreadyHandled(t *testing.T) {
+	orig := &AlreadyHandledError{OriginalError: fmt.Errorf("boom")}
+	wrapped := fmt.Errorf("failed to install charts: %w", orig)
+	got := HandleGlobalError(wrapped, false)
+	if got != wrapped {
+		t.Fatalf("an already-handled error must be returned as-is, not re-rendered or re-wrapped; got %T %v", got, got)
+	}
+}

--- a/internal/shared/errors/retry_policy.go
+++ b/internal/shared/errors/retry_policy.go
@@ -27,6 +27,15 @@ type RecoverableError interface {
 	GetRetryAfter() time.Duration
 }
 
+// NonRetryableError marks errors that must NEVER be retried, no matter what
+// their text looks like. Needed because the substring fallback below scans the
+// whole message: an app-wait failure embeds pod logs and events, whose content
+// routinely contains transient-looking phrases ("connection refused", "i/o
+// timeout") — retrying it would reinstall an already-installed ArgoCD.
+type NonRetryableError interface {
+	IsNonRetryable() bool
+}
+
 // ExponentialBackoffPolicy implements exponential backoff retry policy
 type ExponentialBackoffPolicy struct {
 	MaxAttempts   int
@@ -73,11 +82,22 @@ func (p *ExponentialBackoffPolicy) ShouldRetry(err error, attempt int) bool {
 		return false
 	}
 
-	// Check if it's a recoverable error. errors.As unwraps %w chains, so a
-	// recoverable error stays recognized after being wrapped.
+	// An explicit "never retry" marker wins over everything below, including
+	// the substring fallback (see NonRetryableError).
+	var nonRetryable NonRetryableError
+	if stderrors.As(err, &nonRetryable) && nonRetryable.IsNonRetryable() {
+		return false
+	}
+
+	// Check if it's an explicitly recoverable error. errors.As unwraps %w
+	// chains, so a recoverable error stays recognized after being wrapped.
+	// Only a positive marking short-circuits: Recoverable defaults to false on
+	// every wrapper (e.g. ChartError), so treating that default as a veto made
+	// the transient classification below unreachable for install failures —
+	// the retry policy's own table never ran.
 	var recoverableErr RecoverableError
-	if stderrors.As(err, &recoverableErr) {
-		return recoverableErr.IsRecoverable()
+	if stderrors.As(err, &recoverableErr) && recoverableErr.IsRecoverable() {
+		return true
 	}
 
 	// Structural classification first — it does not depend on the wording of

--- a/internal/shared/errors/retry_policy_test.go
+++ b/internal/shared/errors/retry_policy_test.go
@@ -223,3 +223,45 @@ func TestInstallationRetryPolicy_DropsDeadHelm2Pattern(t *testing.T) {
 	assert.False(t, p.ShouldRetry(errors.New("network timeout"), 0),
 		"the phantom phrase must no longer be a retry trigger")
 }
+
+// wrapperErr mimics ChartError: a wrapper implementing RecoverableError whose
+// Recoverable defaults to false (i.e. "unclassified", not "forbidden").
+type wrapperErr struct {
+	msg         string
+	recoverable bool
+}
+
+func (w *wrapperErr) Error() string              { return w.msg }
+func (w *wrapperErr) IsRecoverable() bool        { return w.recoverable }
+func (w *wrapperErr) GetRetryAfter() time.Duration { return 0 }
+
+type nonRetryableErr struct{ msg string }
+
+func (n *nonRetryableErr) Error() string        { return n.msg }
+func (n *nonRetryableErr) IsNonRetryable() bool { return true }
+
+// An unmarked wrapper (Recoverable=false by default) must not veto the
+// transient classification: every install failure arrives wrapped in a
+// ChartError, so the early return made the policy's own retryable table
+// unreachable and MaxAttempts=3 a fiction.
+func TestShouldRetry_UnmarkedWrapperFallsThroughToClassification(t *testing.T) {
+	p := InstallationRetryPolicy().(*ExponentialBackoffPolicy)
+	err := &wrapperErr{msg: "installation failed for ArgoCD: connection refused"}
+	assert.True(t, p.ShouldRetry(err, 1),
+		"a transient cause behind an unmarked wrapper must be retried")
+}
+
+func TestShouldRetry_ExplicitlyRecoverableWins(t *testing.T) {
+	p := InstallationRetryPolicy().(*ExponentialBackoffPolicy)
+	err := &wrapperErr{msg: "some opaque failure", recoverable: true}
+	assert.True(t, p.ShouldRetry(err, 1))
+}
+
+// An explicit non-retryable marker beats even transient-looking text: the
+// app-wait failure embeds pod logs whose content routinely contains phrases
+// like "connection refused" — retrying it would reinstall ArgoCD.
+func TestShouldRetry_NonRetryableMarkerBeatsTransientText(t *testing.T) {
+	p := InstallationRetryPolicy().(*ExponentialBackoffPolicy)
+	err := &nonRetryableErr{msg: "waiting failed: pod log: connect: connection refused; i/o timeout"}
+	assert.False(t, p.ShouldRetry(err, 1))
+}

--- a/internal/shared/executor/executor.go
+++ b/internal/shared/executor/executor.go
@@ -384,21 +384,28 @@ func (e *RealCommandExecutor) ExecuteWithOptions(ctx context.Context, options Ex
 		cmd.Stdin = bytes.NewReader(options.Stdin)
 	}
 
-	// Execute the command
-	stdout, err := cmd.Output()
+	// Execute the command with explicit stdout/stderr buffers. cmd.Output()
+	// only surfaces stderr through *exec.ExitError, i.e. exclusively on
+	// failure — a successful run's stderr (helm deprecation/ownership
+	// warnings, gcloud notices) was silently dropped, leaving the callers'
+	// "show stderr in verbose mode" branches dead.
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
 	result.Duration = time.Since(start)
-	result.Stdout = string(stdout)
+	result.Stdout = stdoutBuf.String()
+	// Redact at the population chokepoint: callers embed Stderr in
+	// user-facing errors even in non-verbose mode (e.g. the helm
+	// manager's "Helm output: %s"), and a child process can echo a
+	// token back. Control-flow substring checks downstream match
+	// generic phrases, never secret values, so redaction is safe here.
+	result.Stderr = redact.Redact(stderrBuf.String())
 
 	if err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
 			result.ExitCode = exitError.ExitCode()
-			// Redact at the population chokepoint: callers embed Stderr in
-			// user-facing errors even in non-verbose mode (e.g. the helm
-			// manager's "Helm output: %s"), and a child process can echo a
-			// token back. Control-flow substring checks downstream match
-			// generic phrases, never secret values, so redaction is safe here.
-			result.Stderr = redact.Redact(string(exitError.Stderr))
 		} else {
 			result.ExitCode = -1
 		}

--- a/internal/shared/executor/executor_test.go
+++ b/internal/shared/executor/executor_test.go
@@ -404,3 +404,16 @@ func TestResetWSLCache(t *testing.T) {
 	// Actual caching behavior depends on the OS
 	ResetWSLCache()
 }
+
+// A successful command's stderr must be captured too: helm/gcloud print
+// deprecation and ownership warnings there on exit code 0, and the callers'
+// "show stderr in verbose mode" branches were dead because cmd.Output() only
+// surfaces stderr through *exec.ExitError (i.e. on failure).
+func TestRealCommandExecutor_Execute_CapturesStderrOnSuccess(t *testing.T) {
+	e := NewRealCommandExecutor(false, false)
+	result, err := e.Execute(context.Background(), "sh", "-c", "echo out; echo warn 1>&2")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, result.Stdout, "out")
+	assert.Contains(t, result.Stderr, "warn")
+}

--- a/internal/shared/ui/silent.go
+++ b/internal/shared/ui/silent.go
@@ -4,7 +4,24 @@ import (
 	"io"
 
 	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 )
+
+// ApplyGlobalOutputFlags applies the root command's --silent/--verbose
+// contract. Cobra runs only the CLOSEST parent's PersistentPreRunE, so any
+// command group that defines its own hook shadows the root's — it must call
+// this first, or --verbose is silently inert for its whole subtree (the
+// executor's failed-command diagnostics, among ~40 other pterm.Debug sites,
+// live behind it). --silent wins when both are given.
+func ApplyGlobalOutputFlags(cmd *cobra.Command) {
+	silentFlag, _ := cmd.Flags().GetBool("silent")
+	if silentFlag {
+		SetSilent()
+	}
+	if v, _ := cmd.Flags().GetBool("verbose"); v && !silentFlag {
+		pterm.EnableDebugMessages()
+	}
+}
 
 // silent records whether --silent suppressed non-error output. Read by the logo
 // renderer so it can honor the flag.
@@ -33,6 +50,7 @@ func SetSilent() {
 	pterm.DefaultBox = *pterm.DefaultBox.WithWriter(io.Discard)
 	pterm.DefaultHeader = *pterm.DefaultHeader.WithWriter(io.Discard)
 	pterm.DefaultTable = *pterm.DefaultTable.WithWriter(io.Discard)
+	pterm.DefaultSection = *pterm.DefaultSection.WithWriter(io.Discard)
 	// Interactive prompt printers (DefaultInteractiveConfirm/TextInput) are left
 	// alone on purpose: discarding their writer would hide the prompt text while
 	// it still blocks on stdin — a silent hang, worse than a visible prompt.

--- a/internal/shared/ui/silent_test.go
+++ b/internal/shared/ui/silent_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +47,37 @@ func TestShowLogoConditional_SilentSkips(t *testing.T) {
 	// guard path (no panic, no output).
 	ShowLogoConditional(false)
 	assert.True(t, silent)
+}
+
+// The section printer is non-error output too: `app access --silent` used to
+// print its header — and the admin password via raw pterm.Printf — to stdout.
+func TestSetSilent_DiscardsSectionPrinter(t *testing.T) {
+	savedSilent := silent
+	t.Cleanup(func() { silent = savedSilent })
+
+	SetSilent()
+	assert.Equal(t, io.Discard, pterm.DefaultSection.Writer, "DefaultSection must be discarded under --silent")
+}
+
+// Command groups that shadow the root's PersistentPreRunE call this helper;
+// it must apply BOTH halves of the global output contract.
+func TestApplyGlobalOutputFlags(t *testing.T) {
+	t.Run("verbose enables debug output", func(t *testing.T) {
+		t.Cleanup(pterm.DisableDebugMessages)
+		cmd := &cobra.Command{Use: "x"}
+		cmd.Flags().Bool("silent", false, "")
+		cmd.Flags().Bool("verbose", true, "")
+		ApplyGlobalOutputFlags(cmd)
+		assert.True(t, pterm.PrintDebugMessages, "--verbose must enable pterm debug output")
+	})
+
+	t.Run("silent wins over verbose", func(t *testing.T) {
+		savedSilent := silent
+		t.Cleanup(func() { silent = savedSilent; pterm.DisableDebugMessages() })
+		cmd := &cobra.Command{Use: "x"}
+		cmd.Flags().Bool("silent", true, "")
+		cmd.Flags().Bool("verbose", true, "")
+		ApplyGlobalOutputFlags(cmd)
+		assert.False(t, pterm.PrintDebugMessages, "--silent must suppress debug output even with --verbose")
+	})
 }


### PR DESCRIPTION
fix(chart): reachable timeout diagnostics, attributable fail-fast, working retry policy, honest dry-run
fix(cluster): cloud-aware status path, location-scoped disk sweep, node-bound validation, resume correctness
fix(errors): stop the friendly hint misfiring on embedded diagnostics; drop the doubled error prefix