### PR TITLE
fix(ui): keep periodic log lines out of the live surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ openframe app install                           # interactive: pick context
 openframe app install dev --non-interactive     # reuse existing openframe-helm-values.yaml
 openframe app install -c k3d-dev --ref v1.3.0   # deploy a specific release tag
 openframe app status  -c k3d-dev                # -o json|yaml supported
+openframe app status  -c k3d-dev --watch        # live view, refreshes in place (Ctrl+C to exit)
+openframe app status  -c k3d-dev --interactive  # k9s-style TUI: navigate apps, inspect, trigger syncs
 openframe app access  -c k3d-dev                # ArgoCD URL + admin credentials
 openframe app upgrade -c k3d-dev --sync         # force ArgoCD to re-sync current ref
 openframe app upgrade -c k3d-dev --ref v1.4.0   # move to a new release tag
@@ -210,9 +212,33 @@ openframe update v1.4.0     # switch to a specific release (up or down)
 openframe update rollback   # revert to the previous version, offline
 ```
 
+## Terminal Output
+
+On an interactive terminal the CLI renders live surfaces: a stage checklist
+with per-stage timings during `bootstrap`, an in-place dashboard during the
+application wait (progress bar, per-app health, slowest-apps timing), download
+progress bars, and a desktop notification when a long install finishes. Long
+operations under `--verbose`, `--plain`, or redirected output switch to
+timestamped sequential log lines that carry the same information (ready
+deltas, pending apps with their health).
+
+Output controls:
+
+- `--plain` — sequential output with colors but no spinners or in-place
+  redraws (for `watch`, `script`, tmux logging)
+- `--silent` — suppress everything except errors
+- `--verbose` — timestamped debug lines (helm/k3d command lines, wait internals)
+- `NO_COLOR` / `CLICOLOR_FORCE=1` — strip / force ANSI styling
+- `OPENFRAME_ASCII=1` — plain ASCII glyphs (also automatic under `TERM=dumb`
+  or a non-UTF-8 locale)
+
+In GitHub Actions, bootstrap stages fold into log groups, failures surface as
+job annotations, and the closing summary lands in the job's Step Summary.
+
 Non-interactive flags (`--non-interactive`, `--yes`, `--force`, `--skip-wizard`)
 make every command scriptable; prompts are also skipped automatically in CI or
-when stdin is not a terminal.
+when stdin is not a terminal. See [Terminal output reference](./docs/reference/terminal-output.md)
+for the full behavior matrix.
 
 ## Technology Stack
 

--- a/cmd/app/status.go
+++ b/cmd/app/status.go
@@ -50,8 +50,8 @@ func runStatusCommand(cmd *cobra.Command, _ []string) error {
 	if (watch || interactive) && format != "text" {
 		return fmt.Errorf("--watch/--interactive are live terminal views and cannot combine with --output %s", format)
 	}
-	if (watch || interactive) && !ui.IsTerminal() {
-		return fmt.Errorf("--watch/--interactive need an interactive terminal")
+	if (watch || interactive) && (!ui.IsTerminal() || ui.IsPlain()) {
+		return fmt.Errorf("--watch/--interactive need an interactive terminal (and cannot combine with --plain)")
 	}
 
 	cfg, err := resolveRestConfig(contextName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,6 +148,7 @@ operation for automation and power users.`,
 	// Add global flags following cluster pattern
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().Bool("silent", false, "Suppress all output except errors")
+	rootCmd.PersistentFlags().Bool("plain", false, "Sequential output without spinners or in-place redraws (for scripts, tmux logging, watch)")
 
 	// Version template
 	rootCmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,11 +13,15 @@ This repository (`flamingo-stack/openframe-cli`) is the CLI. The platform and ap
 - [Cloud Clusters](./getting-started/cloud-clusters.md) — Provision EKS/GKE clusters with Terraform (reference)
 - [GKE Workflow](./getting-started/gke-workflow.md) — Step-by-step: from zero to a running GKE cluster
 
+## Reference
+
+- [Terminal Output](./reference/terminal-output.md) — Live dashboards, sequential/CI mode, `--plain`/`--silent`/`--verbose`, color and glyph controls, GitHub Actions integration
+
 ## Commands
 
 - `openframe bootstrap` — Create a cluster and install the platform in one step
 - `openframe cluster {create,delete,list,status,cleanup}` — Manage k3d and cloud (EKS/GKE) clusters
-- `openframe app {install,upgrade,status,access,uninstall}` — Manage the OpenFrame app-of-apps deployment
+- `openframe app {install,upgrade,status,access,uninstall}` — Manage the OpenFrame app-of-apps deployment (`status` also has `--watch` and `--interactive` live views)
 - `openframe prerequisites {check,install}` — Check and install required tools
 - `openframe update` (`check`, `rollback`, `update <version>`) — Self-update the CLI
 - `openframe completion` — Generate shell completion scripts

--- a/docs/reference/terminal-output.md
+++ b/docs/reference/terminal-output.md
@@ -1,0 +1,107 @@
+# Terminal output reference
+
+The CLI picks an output mode per command from the terminal it runs in and the
+flags it was given. Exactly one "live" surface is ever active at a time; every
+other consumer gets sequential, log-friendly lines carrying the same
+information.
+
+## Output modes
+
+| Mode | When | What you see |
+|------|------|--------------|
+| Live | interactive terminal, no `--verbose`/`--plain`/`--silent` | animated spinners, the in-place application dashboard, download progress bars |
+| Sequential | redirected output, CI, `--plain`, `--verbose` | timestamped log lines: heartbeats with ready-deltas, stage lines, download begin/done announces |
+| Silent | `--silent` | errors only |
+| Machine | `-o json` / `-o yaml` | data on stdout, human warnings on stderr |
+
+## Live surfaces
+
+- **Stage checklist** (`bootstrap`) — each stage prints `◉ [2/3] Create
+  cluster`, closes with `✔`/`✖` and its duration, and the run ends with a
+  summary card: cluster + kube-context, per-stage timings, next commands.
+- **Application dashboard** (install/bootstrap wait) — an in-place block with
+  an animated header, elapsed time, a progress bar (`14/17 ready`), and the
+  not-ready applications colored by health (red `Degraded`, yellow
+  `Progressing`), capped at 8 with `+N more`. One-off events (stall hints,
+  repo-server recovery notices) pin under the block as notes. The success
+  line reports which applications took longest to become ready.
+- **`app status --watch`** — the platform status re-rendered in place every
+  3 s; a failing poll shows its error inside the view and keeps watching.
+- **`app status --interactive`** — a k9s-style TUI over the ArgoCD
+  applications: arrows/`j`/`k` navigate, `enter` opens the app detail (repo,
+  path, target ref, revision, conditions, operation state), `s` triggers a
+  per-app sync, `r` refreshes, `q` quits. Auto-refreshes every 3 s.
+- **Download progress** — a self-rewriting line with a bar, percentage, and
+  speed for verified tool downloads.
+- **Desktop notification** — long operations (bootstrap, install) emit an
+  OSC 9 notification plus a terminal bell on completion or failure, for the
+  user who switched to another window.
+
+`--watch` and `--interactive` require an interactive terminal and reject
+machine output and `--plain`.
+
+## Sequential mode
+
+Where the live surfaces cannot run (redirected output, CI, `--plain`,
+`--verbose`), the same information arrives as self-sufficient log lines:
+
+- **Wait heartbeat** (every 30 s, 10 s under `--verbose`):
+  `[12:34:05] apps 14/17 ready (+2 since last check) · elapsed 12m30s` with a
+  `pending: tenant(Progressing), gateway(Degraded)` detail line. A `+0` delta
+  makes a stall visible without diffing counts.
+- **Interruption state** — Ctrl+C or a cancelled CI job during the wait
+  records `interrupted at 14/17 applications ready · pending: …` before the
+  cancellation error.
+- **Download announces** — `Downloading helm-v3.16.2.tar.gz (52 MB)...` and
+  `Downloaded … in 4.2s` replace the live bar.
+- **Phase heartbeats** — output-less blocking operations (`helm --wait`)
+  emit `<label> (2m30s elapsed)` every 30 s so a long phase is
+  distinguishable from a hang.
+- **Timestamped `--verbose`** — every debug line starts with a wall-clock
+  stamp (`15:04:05.000`) so CLI actions can be correlated with cluster
+  events.
+
+## Failure panel
+
+Failures render as an aligned panel instead of a wall of text:
+
+```
+✖ create failed for cluster big-gke
+  cause   googleapi: Error 403: quota exceeded
+  hint    💡 Request more quota, lower --nodes, or pick another region
+  resume  openframe cluster create big-gke
+```
+
+`--verbose` adds the full error chain as a `chain` row.
+
+## Flags and environment
+
+| Control | Effect |
+|---------|--------|
+| `--plain` | sequential output with colors; no spinners, areas, or self-rewriting lines |
+| `--silent` | errors only (also skips the logo and notifications) |
+| `--verbose` | timestamped debug lines; disables the dashboard in favor of scrolling logs |
+| `NO_COLOR` (non-empty) | strips all ANSI styling ([no-color.org](https://no-color.org)) |
+| `CLICOLOR_FORCE=1` | keeps styling even when `NO_COLOR` is set |
+| `OPENFRAME_ASCII=1` | plain ASCII glyphs (`ok`/`x`/`->`) instead of Unicode |
+| `TERM=dumb` | implies ASCII glyphs and disables terminal escapes |
+| `OPENFRAME_APP_WAIT_TIMEOUT` | application-wait budget (Go duration, default `60m`) |
+| `OPENFRAME_DEGRADED_FAIL_AFTER` | how long an app may stay Degraded+Synced before the fail-fast considers it stuck (default `8m`) |
+
+ANSI styling stays on for plain non-TTY output by default — modern CI log
+renderers display it; `NO_COLOR` is the opt-out for consumers that don't.
+
+Hyperlinks (OSC 8) are emitted only on terminals known to support them
+(iTerm2, WezTerm, ghostty, Konsole, VTE-based, VS Code); everywhere else the
+plain URL is printed.
+
+## GitHub Actions
+
+Inside a GitHub Actions job (`GITHUB_ACTIONS=true`):
+
+- bootstrap stages fold into `::group::` log groups (the `✔`/`✖` closing
+  lines stay outside the fold);
+- the failure panel doubles as an `::error::` annotation with the headline
+  and root cause, visible on the job and the PR;
+- the closing bootstrap summary is appended to the job's Step Summary as a
+  markdown table (stage, duration).

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -125,7 +125,8 @@ func (s *Service) bootstrap(ctx context.Context, clusterName string, nonInteract
 }
 
 // printBootstrapSummary is the closing card: what was built, how long each
-// stage took, and where to go next.
+// stage took, and where to go next. In GitHub Actions the same card lands in
+// the job's Step Summary panel as markdown.
 func printBootstrapSummary(clusterName string, tracker *steps.Tracker) {
 	g := ui.Glyphs()
 	pterm.DefaultBasicText.Println()
@@ -134,6 +135,24 @@ func printBootstrapSummary(clusterName string, tracker *steps.Tracker) {
 	ui.SummaryRow("stages", steps.TimingsLine(tracker.Timings()))
 	ui.SummaryRow("status", "openframe app status")
 	ui.SummaryRow("access", "openframe app access   (ArgoCD UI credentials)")
+	ui.AppendStepSummary(bootstrapSummaryMarkdown(clusterName, tracker))
+}
+
+// bootstrapSummaryMarkdown renders the closing card for the GitHub Actions
+// Step Summary panel.
+func bootstrapSummaryMarkdown(clusterName string, tracker *steps.Tracker) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "### OpenFrame ready · %s\n\n", steps.FormatDuration(tracker.Total()))
+	fmt.Fprintf(&b, "**Cluster:** `%s`\n\n", clusterName)
+	b.WriteString("| stage | duration |\n|---|---|\n")
+	for _, tm := range tracker.Timings() {
+		mark := ""
+		if tm.Failed {
+			mark = " ✖"
+		}
+		fmt.Fprintf(&b, "| %s%s | %s |\n", tm.Title, mark, steps.FormatDuration(tm.Duration))
+	}
+	return b.String()
 }
 
 // createClusterSuppressed creates a cluster with suppressed UI elements

--- a/internal/chart/providers/argocd/dashboard.go
+++ b/internal/chart/providers/argocd/dashboard.go
@@ -40,7 +40,7 @@ type appDashboard struct {
 const dashboardMaxApps = 8
 
 func newAppDashboard() *appDashboard {
-	if !ui.IsTerminal() || ui.IsSilent() {
+	if !ui.Animated() {
 		return nil
 	}
 	area, err := pterm.DefaultArea.Start()
@@ -128,6 +128,36 @@ func notReadyLines(apps []Application) string {
 		fmt.Fprintf(&b, "    %-*s  %s\n", nameW, a.Name, state)
 	}
 	return b.String()
+}
+
+// pendingSummary renders the not-ready apps with their health for one-line
+// log output — "tenant(Progressing), gateway(Degraded), +3 more" — so a
+// scrollback reader sees WHO is pending and HOW BAD without a table.
+func pendingSummary(apps []Application, limit int) string {
+	var pending []Application
+	for _, a := range apps {
+		if a.Health == ArgoCDHealthHealthy && a.Sync == ArgoCDSyncSynced {
+			continue
+		}
+		pending = append(pending, a)
+	}
+	if len(pending) == 0 {
+		return ""
+	}
+	sort.Slice(pending, func(i, j int) bool { return pending[i].Name < pending[j].Name })
+	parts := make([]string, 0, limit+1)
+	for i, a := range pending {
+		if i >= limit {
+			parts = append(parts, fmt.Sprintf("+%d more", len(pending)-limit))
+			break
+		}
+		state := a.Health
+		if state == "" {
+			state = a.Sync
+		}
+		parts = append(parts, fmt.Sprintf("%s(%s)", a.Name, state))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // Note pins a one-off event line (stall hint, recovery notice) under the

--- a/internal/chart/providers/argocd/dashboard_test.go
+++ b/internal/chart/providers/argocd/dashboard_test.go
@@ -66,3 +66,25 @@ func TestAppDashboard_SlowestLine(t *testing.T) {
 		t.Fatal("no ready apps → empty line")
 	}
 }
+
+func TestPendingSummary(t *testing.T) {
+	apps := []Application{
+		{Name: "ready", Health: ArgoCDHealthHealthy, Sync: ArgoCDSyncSynced},
+		{Name: "tenant", Health: ArgoCDHealthProgressing, Sync: ArgoCDSyncSynced},
+		{Name: "gateway", Health: ArgoCDHealthDegraded, Sync: ArgoCDSyncSynced},
+	}
+	got := pendingSummary(apps, 6)
+	if got != "gateway(Degraded), tenant(Progressing)" {
+		t.Fatalf("pendingSummary = %q", got)
+	}
+	if pendingSummary(apps[:1], 6) != "" {
+		t.Fatal("all-ready must render empty")
+	}
+	var many []Application
+	for _, n := range []string{"a", "b", "c", "d"} {
+		many = append(many, Application{Name: n, Health: ArgoCDHealthProgressing})
+	}
+	if got := pendingSummary(many, 2); got != "a(Progressing), b(Progressing), +2 more" {
+		t.Fatalf("capped summary = %q", got)
+	}
+}

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -111,6 +111,17 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	var spinnerMutex sync.Mutex
 	spinnerStopped := false
 
+	// waitNote routes one-off in-wait announcements: pinned under the live
+	// dashboard when it is active (a plain print would be visually swallowed
+	// by the area redraw within 2s), ordinary silence-aware prints otherwise.
+	waitNote := func(styled string) {
+		if dash != nil {
+			dash.Note(styled)
+			return
+		}
+		pterm.DefaultBasicText.Println(styled)
+	}
+
 	// Function to stop spinner safely
 	stopSpinner := func() {
 		dash.Stop()
@@ -390,7 +401,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 
 			// Reset consecutive failures on successful query
 			if consecutiveFailures > 0 {
-				pterm.Success.Println("Application queries restored")
+				waitNote(pterm.Success.Sprint("Application queries restored"))
 				consecutiveFailures = 0
 			}
 
@@ -474,17 +485,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 				// which is exactly the path they are already on. Gating the hint on
 				// !stragglerSyncTriggered instead would print that contradictory
 				// advice on every stall tick after the one-shot sync.
-				// When the dashboard is live these lines pin under it as
-				// notes — a plain print would be visually swallowed by the
-				// area redraw.
-				stallNote := func(styled string) {
-					if dash != nil {
-						dash.Note(styled)
-						return
-					}
-					// DefaultBasicText, not raw print: --silent redirects it.
-					pterm.DefaultBasicText.Println(styled)
-				}
+				stallNote := waitNote
 				if config.SyncStragglersOnStall {
 					if !stragglerSyncTriggered {
 						stragglerSyncTriggered = true
@@ -573,15 +574,15 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 									// out to its timeout. triggerRepoServerRecovery already
 									// hard-refreshed app.Name; cover the rest.
 									if refreshed := m.hardRefreshApplications(localCtx, appNames(unknownApps)); refreshed > 0 {
-										pterm.Info.Printfln("Hard-refreshed %d application(s) stuck in Unknown.", refreshed)
+										waitNote(pterm.Info.Sprintf("Hard-refreshed %d application(s) stuck in Unknown.", refreshed))
 									}
 								} else {
-									pterm.Warning.Println("Could not restart the ArgoCD repo-server; continuing to wait.")
+									waitNote(pterm.Warning.Sprint("Could not restart the ArgoCD repo-server; continuing to wait."))
 								}
 							} else if repoServerRecoveryAttempts == maxRepoServerRecoveryAttempts {
 								repoServerRecoveryAttempts++ // prevent repeated attempts
-								pterm.Warning.Printfln("ArgoCD repo-server did not recover after %d restarts; continuing to wait for the timeout.",
-									maxRepoServerRecoveryAttempts)
+								waitNote(pterm.Warning.Sprintf("ArgoCD repo-server did not recover after %d restarts; continuing to wait for the timeout.",
+									maxRepoServerRecoveryAttempts))
 							}
 							break // Only recover one app at a time
 						}
@@ -593,18 +594,19 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 				// (throttled); the per-application dump stays behind --verbose.
 				if len(unknownApps) > 0 && elapsed > 5*time.Minute && time.Since(lastUnknownWarn) >= 5*time.Minute {
 					lastUnknownWarn = time.Now()
-					pterm.Warning.Printfln("  %d application(s) have 'Unknown' status after %s. Possible causes: controller pod not ready, git repository unreachable, or resource constraints.",
-						len(unknownApps), elapsed.Round(time.Second))
+					waitNote(pterm.Warning.Sprintf("%d application(s) have 'Unknown' status after %s. Possible causes: controller pod not ready, git repository unreachable, or resource constraints.",
+						len(unknownApps), elapsed.Round(time.Second)))
 					if config.Verbose {
 						describeUnknownApps(unknownApps)
-					} else {
+					} else if dash == nil {
 						pterm.Info.Println("  Re-run with --verbose for per-application detail.")
 					}
 				}
 
 				// A concise summary of stuck applications, every 5 minutes after the
-				// 7-minute mark (in-memory status; no kubectl resource dump).
-				if elapsed > 7*time.Minute && time.Since(lastStuckSummary) >= 5*time.Minute {
+				// 7-minute mark (in-memory status; no kubectl resource dump). The
+				// dashboard already shows exactly this, live — sequential modes only.
+				if dash == nil && elapsed > 7*time.Minute && time.Since(lastStuckSummary) >= 5*time.Minute {
 					lastStuckSummary = time.Now()
 					for _, app := range apps {
 						if app.Health != ArgoCDHealthHealthy && app.Health != ArgoCDHealthMissing {
@@ -623,8 +625,10 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 			// self-sufficient for scrollback reading: wall clock (correlate
 			// with cluster events), the delta since the previous beat (a zero
 			// delta screams "stalled" without diffing counts by eye), and the
-			// pending apps WITH their health, not just names.
-			if totalApps > 0 && time.Since(lastProgressPrint) >= progressPrintInterval {
+			// pending apps WITH their health, not just names. Never alongside
+			// the live dashboard — a foreign print every 30s would garble the
+			// area redraw, and the dashboard already shows all of it.
+			if dash == nil && totalApps > 0 && time.Since(lastProgressPrint) >= progressPrintInterval {
 				lastProgressPrint = time.Now()
 				delta := currentlyReady - heartbeatLastReady
 				heartbeatLastReady = currentlyReady

--- a/internal/chart/providers/argocd/wait.go
+++ b/internal/chart/providers/argocd/wait.go
@@ -246,6 +246,7 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	var lastNotReadyNames []string   // bare names, for the kubectl example
 	var lastNotReadyDetails []string // per-app health messages, for the timeout diagnostic
 	lastReadyCount, lastTotalApps := 0, 0
+	heartbeatLastReady := 0
 	// The spinner already animates for interactive users, so the textual line is
 	// mainly a heartbeat for logs and CI; verbose users want it more often.
 	progressPrintInterval := 30 * time.Second
@@ -257,6 +258,16 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 	for {
 		select {
 		case <-localCtx.Done():
+			// Last-known-state line for the sequential modes: a Ctrl+C or a
+			// cancelled CI job records where the install stood instead of
+			// ending on a bare "operation cancelled".
+			if dash == nil && lastTotalApps > 0 {
+				line := fmt.Sprintf("interrupted at %d/%d applications ready", lastReadyCount, lastTotalApps)
+				if len(lastNotReadyNames) > 0 {
+					line += fmt.Sprintf(" · pending: %s", strings.Join(lastNotReadyNames, ", "))
+				}
+				pterm.DefaultBasicText.Println(line)
+			}
 			return fmt.Errorf("operation cancelled: %w", localCtx.Err())
 		case <-ticker.C:
 			// Check timeout
@@ -607,21 +618,20 @@ func (m *Manager) WaitForApplications(ctx context.Context, config config.ChartIn
 				}
 			}
 
-			// Textual progress heartbeat. The spinner covers interactive users; this
-			// line is what a CI log or a piped session sees, where the spinner is
-			// suppressed entirely and the previous code printed nothing at all.
+			// Textual progress heartbeat — what a log, a piped session, --plain,
+			// or a --verbose run sees instead of the dashboard. Each line is
+			// self-sufficient for scrollback reading: wall clock (correlate
+			// with cluster events), the delta since the previous beat (a zero
+			// delta screams "stalled" without diffing counts by eye), and the
+			// pending apps WITH their health, not just names.
 			if totalApps > 0 && time.Since(lastProgressPrint) >= progressPrintInterval {
 				lastProgressPrint = time.Now()
-				pterm.Info.Printf("ArgoCD sync progress: %d/%d applications ready (%s elapsed)\n",
-					currentlyReady, totalApps, elapsed.Round(time.Second))
-
-				if len(notReadyApps) > 0 {
-					if len(notReadyApps) <= 8 {
-						pterm.Info.Printf("  Still waiting for: %v\n", notReadyApps)
-					} else {
-						pterm.Info.Printf("  Still waiting for %d applications (showing first 5): %v...\n",
-							len(notReadyApps), notReadyApps[:5])
-					}
+				delta := currentlyReady - heartbeatLastReady
+				heartbeatLastReady = currentlyReady
+				pterm.Info.Printf("[%s] apps %d/%d ready (%+d since last check) · elapsed %s\n",
+					time.Now().Format("15:04:05"), currentlyReady, totalApps, delta, elapsed.Round(time.Second))
+				if p := pendingSummary(apps, 6); p != "" {
+					pterm.Info.Printf("  pending: %s\n", p)
 				}
 				if config.Verbose && len(healthyApps) > 0 && len(healthyApps) <= 5 {
 					pterm.Debug.Printf("  Recently completed: %v\n", healthyApps)

--- a/internal/shared/download/progress.go
+++ b/internal/shared/download/progress.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/flamingo-stack/openframe-cli/internal/shared/ui/spinner"
+	"github.com/pterm/pterm"
 )
 
 // Download progress: a single self-rewriting line on stderr —
@@ -24,7 +25,15 @@ const progressRenderInterval = 120 * time.Millisecond
 
 // progressEnabled gates the bar to safe contexts (see package comment above).
 func progressEnabled() bool {
-	return ui.IsTerminal() && !ui.IsSilent() && !spinner.AnyActive()
+	return ui.Animated() && !spinner.AnyActive()
+}
+
+// announceEnabled gates the sequential begin/done lines used where the live
+// bar cannot run (non-TTY, --plain): a 50 MB download used to be complete
+// silence there. When a spinner is animating, its own text already covers
+// the story; --silent stays silent.
+func announceEnabled() bool {
+	return !ui.IsSilent() && !spinner.AnyActive() && !progressEnabled()
 }
 
 // progressReader wraps a download body and renders the progress line as the
@@ -73,6 +82,21 @@ func (p *progressReader) done() {
 	if p.rendered {
 		fmt.Fprint(p.out, "\r\033[K")
 	}
+}
+
+// announceStart/announceDone are the sequential begin/done pair for contexts
+// without the live bar. Duration-only on done — the byte count already ran in
+// the start line when the server sent a length.
+func announceStart(label string, total int64) {
+	if total > 0 {
+		pterm.Info.Printf("Downloading %s (%s)...\n", label, humanBytes(total))
+		return
+	}
+	pterm.Info.Printf("Downloading %s...\n", label)
+}
+
+func announceDone(label string, took time.Duration) {
+	pterm.Info.Printf("Downloaded %s in %s\n", label, took.Round(100*time.Millisecond))
 }
 
 // humanBytes renders a byte count for humans: 512 B, 3.4 MB, 1.2 GB.

--- a/internal/shared/download/verify.go
+++ b/internal/shared/download/verify.go
@@ -108,10 +108,15 @@ func (d Downloader) FetchVerified(ctx context.Context, asset PinnedAsset) ([]byt
 	// pinned assets (tool binaries / archives) are tens of MB; 512 MiB is a
 	// generous ceiling. Read one byte past to detect an over-cap body.
 	src := io.LimitReader(resp.Body, maxAssetBytes+1)
+	label := assetLabel(asset.URL)
 	if progressEnabled() {
-		pr := newProgressReader(src, assetLabel(asset.URL), resp.ContentLength)
+		pr := newProgressReader(src, label, resp.ContentLength)
 		defer pr.done()
 		src = pr
+	} else if announceEnabled() {
+		announceStart(label, resp.ContentLength)
+		start := time.Now()
+		defer func() { announceDone(label, time.Since(start)) }()
 	}
 	body, err := io.ReadAll(src)
 	if err != nil {

--- a/internal/shared/errors/errors.go
+++ b/internal/shared/errors/errors.go
@@ -139,6 +139,9 @@ func (eh *ErrorHandler) handleGenericError(err error) {
 	}
 
 	headline, cause := splitCause(err)
+	// In GitHub Actions the failure also becomes a job/PR annotation, so the
+	// cause is visible without opening the 40-minute log.
+	ui.ErrorAnnotation(headline, firstLine(cause))
 	pterm.Error.Printf("%s %s\n", ui.Glyphs().Fail, headline)
 	if cause != "" {
 		panelRow("cause", cause)
@@ -203,6 +206,15 @@ func splitCause(err error) (headline, cause string) {
 		return lines[0], lines[1]
 	}
 	return full, ""
+}
+
+// firstLine trims a possibly multi-line cause (pod logs, terraform output)
+// down to its first line for the one-line annotation surface.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // panelRow prints one aligned "key value" row of the failure panel; multi-line

--- a/internal/shared/ui/ghactions.go
+++ b/internal/shared/ui/ghactions.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GitHub Actions workflow-command helpers. All are no-ops outside an Actions
+// job, so callers wire them unconditionally: stages fold into ::group::
+// blocks, failures surface as job/PR annotations, and the closing summary
+// lands in the job's Step Summary panel — the places a person actually looks
+// when a 20-minute workflow run fails.
+
+// InGitHubActions reports whether the process runs inside a GitHub Actions job.
+func InGitHubActions() bool { return os.Getenv("GITHUB_ACTIONS") == "true" }
+
+// GroupStart opens a foldable log group titled title.
+func GroupStart(title string) {
+	if InGitHubActions() {
+		fmt.Printf("::group::%s\n", escapeAnnotationData(title))
+	}
+}
+
+// GroupEnd closes the innermost log group.
+func GroupEnd() {
+	if InGitHubActions() {
+		fmt.Println("::endgroup::")
+	}
+}
+
+// ErrorAnnotation surfaces a failure as an ::error:: annotation (shown in the
+// job summary and on the PR when applicable).
+func ErrorAnnotation(title, message string) {
+	if !InGitHubActions() {
+		return
+	}
+	fmt.Printf("::error title=%s::%s\n", escapeAnnotationProperty(title), escapeAnnotationData(message))
+}
+
+// AppendStepSummary appends a markdown fragment to the job's Step Summary.
+// Best-effort: a missing or unwritable summary file is silently skipped.
+func AppendStepSummary(markdown string) {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if !InGitHubActions() || path == "" {
+		return
+	}
+	// The runner pre-creates the summary file; 0600 only applies if we are
+	// first, and nothing else needs to read it but the runner (root there).
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 G703 -- GITHUB_STEP_SUMMARY is the Actions runner's own contract: it names the file we are MEANT to append to, and we only ever append markdown
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = f.WriteString(markdown + "\n")
+}
+
+// escapeAnnotationData escapes a workflow-command data value per the Actions
+// runner's rules.
+func escapeAnnotationData(s string) string {
+	r := strings.NewReplacer("%", "%25", "\r", "%0D", "\n", "%0A")
+	return r.Replace(s)
+}
+
+// escapeAnnotationProperty escapes a workflow-command property value (titles
+// need the extra ':' and ',' escapes).
+func escapeAnnotationProperty(s string) string {
+	r := strings.NewReplacer("%", "%25", "\r", "%0D", "\n", "%0A", ":", "%3A", ",", "%2C")
+	return r.Replace(s)
+}

--- a/internal/shared/ui/ghactions_test.go
+++ b/internal/shared/ui/ghactions_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnnotationEscaping(t *testing.T) {
+	if got := escapeAnnotationData("a%b\nc\rd"); got != "a%25b%0Ac%0Dd" {
+		t.Fatalf("data escape = %q", got)
+	}
+	if got := escapeAnnotationProperty("t: a,b"); got != "t%3A a%2Cb" {
+		t.Fatalf("property escape = %q", got)
+	}
+}
+
+func TestAppendStepSummary_WritesOnlyInActions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary.md")
+
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITHUB_STEP_SUMMARY", path)
+	AppendStepSummary("### nope")
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("outside Actions nothing must be written")
+	}
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	AppendStepSummary("### hello")
+	AppendStepSummary("more")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "### hello") || !strings.Contains(string(data), "more") {
+		t.Fatalf("summary = %q", data)
+	}
+}
+
+func TestInGitHubActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	if InGitHubActions() {
+		t.Fatal("empty env → not in Actions")
+	}
+	t.Setenv("GITHUB_ACTIONS", "true")
+	if !InGitHubActions() {
+		t.Fatal("GITHUB_ACTIONS=true → in Actions")
+	}
+}

--- a/internal/shared/ui/plain.go
+++ b/internal/shared/ui/plain.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// plainMode records --plain: keep the output sequential — no spinners, no
+// in-place areas, no self-rewriting progress lines — while keeping colors.
+// For terminal users running the CLI under wrappers (watch, script, tmux
+// panes being logged) where cursor rewriting garbles the capture; non-TTY
+// output degrades the same way automatically, --plain just makes it explicit.
+var plainMode bool
+
+// SetPlain enables plain mode for the process (called from the global flag
+// hook, not meant to be reversed).
+func SetPlain() { plainMode = true }
+
+// IsPlain reports whether --plain sequential output was requested.
+func IsPlain() bool { return plainMode }
+
+// Animated reports whether in-place terminal animation (spinners, live
+// areas, self-rewriting progress) is appropriate: an interactive terminal,
+// not --plain, not --silent.
+func Animated() bool { return IsTerminal() && !plainMode && !IsSilent() }
+
+// ApplyColorContract honors the standard color environment variables:
+// NO_COLOR (any non-empty value) strips all styling, unless CLICOLOR_FORCE=1
+// insists. ANSI stays ON for plain non-TTY output by default — modern CI log
+// renderers (GitHub Actions among them) display it, and NO_COLOR is the
+// explicit opt-out for consumers that don't.
+func ApplyColorContract() {
+	if os.Getenv("CLICOLOR_FORCE") == "1" {
+		return
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		pterm.DisableStyling()
+	}
+}
+
+// NewTimestampWriter wraps w so every line starts with a wall-clock stamp —
+// applied to the debug printer under --verbose, where lines exist to be
+// correlated with cluster events ("which pod restarted while helm hung?")
+// and were previously impossible to place in time.
+func NewTimestampWriter(w io.Writer) io.Writer {
+	return &timestampWriter{out: w, atLineStart: true}
+}
+
+type timestampWriter struct {
+	out         io.Writer
+	atLineStart bool
+}
+
+func (t *timestampWriter) Write(p []byte) (int, error) {
+	var b bytes.Buffer
+	for _, c := range p {
+		if t.atLineStart && c != '\n' {
+			b.WriteString(time.Now().Format("15:04:05.000 "))
+			t.atLineStart = false
+		}
+		b.WriteByte(c)
+		if c == '\n' {
+			t.atLineStart = true
+		}
+	}
+	if _, err := t.out.Write(b.Bytes()); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/shared/ui/plain_test.go
+++ b/internal/shared/ui/plain_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+)
+
+// Every line the timestamp writer emits must start with a wall-clock stamp,
+// including lines split across Write calls; blank lines stay unstamped.
+func TestTimestampWriter(t *testing.T) {
+	var out bytes.Buffer
+	w := NewTimestampWriter(&out)
+	if _, err := w.Write([]byte("first li")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("ne\nsecond\n\nthird\n")); err != nil {
+		t.Fatal(err)
+	}
+	stamped := regexp.MustCompile(`(?m)^\d{2}:\d{2}:\d{2}\.\d{3} `)
+	if got := len(stamped.FindAllString(out.String(), -1)); got != 3 {
+		t.Fatalf("expected 3 stamped lines, got %d in:\n%s", got, out.String())
+	}
+	if regexp.MustCompile(`ne\n\d`).MatchString(out.String()) == false && !bytes.Contains(out.Bytes(), []byte("first line\n")) {
+		t.Fatalf("split line must not be re-stamped mid-line:\n%s", out.String())
+	}
+}

--- a/internal/shared/ui/silent.go
+++ b/internal/shared/ui/silent.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"io"
+	"os"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -14,12 +15,19 @@ import (
 // executor's failed-command diagnostics, among ~40 other pterm.Debug sites,
 // live behind it). --silent wins when both are given.
 func ApplyGlobalOutputFlags(cmd *cobra.Command) {
+	ApplyColorContract()
 	silentFlag, _ := cmd.Flags().GetBool("silent")
 	if silentFlag {
 		SetSilent()
 	}
+	if p, _ := cmd.Flags().GetBool("plain"); p {
+		SetPlain()
+	}
 	if v, _ := cmd.Flags().GetBool("verbose"); v && !silentFlag {
 		pterm.EnableDebugMessages()
+		// Timestamped debug lines: --verbose exists to correlate the CLI's
+		// actions with cluster events, which needs a clock on every line.
+		pterm.Debug = *pterm.Debug.WithWriter(NewTimestampWriter(os.Stdout))
 	}
 }
 

--- a/internal/shared/ui/spinner/heartbeat.go
+++ b/internal/shared/ui/spinner/heartbeat.go
@@ -32,9 +32,12 @@ type Heartbeat struct {
 
 // StartHeartbeat begins emitting "<label> (<elapsed>)" to stderr every interval
 // until Stop is called. interval <= 0 uses defaultHeartbeatInterval. Under
-// --silent it is a no-op (Stop is still safe to call).
+// --silent it is a no-op (Stop is still safe to call), and in an animated
+// session (interactive terminal, no --plain) too: the spinner already shows
+// liveness there, and a periodic stderr line would print straight over the
+// spinner's cursor line.
 func StartHeartbeat(label string, interval time.Duration) *Heartbeat {
-	if ui.IsSilent() {
+	if ui.IsSilent() || ui.Animated() {
 		return &Heartbeat{} // no-op; Stop() tolerates nil channels
 	}
 	return startHeartbeat(os.Stderr, label, interval)

--- a/internal/shared/ui/spinner/spinner.go
+++ b/internal/shared/ui/spinner/spinner.go
@@ -88,6 +88,11 @@ func New() *Spinner {
 	if f, ok := any(os.Stdout).(*os.File); ok {
 		s.isTTY = term.IsTerminal(int(f.Fd()))
 	}
+	// --plain promises sequential output: keep the styled final lines but
+	// never animate over the cursor line.
+	if ui.IsPlain() {
+		s.isTTY = false
+	}
 	return s
 }
 

--- a/internal/shared/ui/steps/steps.go
+++ b/internal/shared/ui/steps/steps.go
@@ -55,6 +55,9 @@ func (t *Tracker) Begin(i int, detail string) {
 		line += " " + pterm.FgGray.Sprint(detail)
 	}
 	pterm.DefaultBasicText.Println(line)
+	// In GitHub Actions the stage's own output folds into a log group titled
+	// after the stage; the ✔/✖ closing line stays outside the fold.
+	ui.GroupStart(fmt.Sprintf("[%d/%d] %s", i+1, len(t.titles), t.titles[i]))
 }
 
 // Done closes stage i successfully, printing its duration.
@@ -69,6 +72,7 @@ func (t *Tracker) finish(i int, failed bool) {
 	}
 	d := time.Since(t.started[i]).Round(100 * time.Millisecond)
 	t.timings = append(t.timings, Timing{Title: t.titles[i], Duration: d, Failed: failed})
+	ui.GroupEnd()
 	g := ui.Glyphs()
 	if failed {
 		pterm.DefaultBasicText.Printf("%s %s %s %s %s\n",


### PR DESCRIPTION
docs: terminal output reference — live surfaces, sequential mode, flags and env controls