### PR TITLE
ci: fix ENOGITREPO in the containerized release plan job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,12 @@ jobs:
           echo "==================================================================="
           echo "===  PLAN: semantic-release dry-run (conventional commits)"
           echo "==================================================================="
+          # The container runs as root while the runner-mounted workspace is
+          # owned by uid 1001, and actions/checkout writes its safe.directory
+          # entry into a TEMPORARY global git config that dies with its step —
+          # so git here refuses the repo ("dubious ownership") and
+          # semantic-release misreports it as ENOGITREPO "not a git repository".
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           npx --yes $SEMREL_PACKAGES semantic-release --dry-run
 
       - name: Report


### PR DESCRIPTION
The plan job's container (node:24-slim) runs as root while the runner-mounted workspace is owned by uid 1001, and actions/checkout writes its safe.directory entry into a TEMPORARY global git config that does not survive its own step. git in the next step then refuses the repository ('detected dubious ownership') and semantic-release misreports it as ENOGITREPO 'not running from a git repository'.

Add the safe.directory entry in the resolve step itself, right before semantic-release runs. Reproduced and verified in a local node:24-slim container: root + uid-1001-owned repo -> fatal dubious ownership; with safe.directory -> git works. The release job is unaffected (macOS runner, no container, no ownership mismatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release automation configuration to prevent deployment pipeline failures and ensure more reliable release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->