### PR TITLE
ci: grant the release plan job push-probe permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     # Pinned Node toolchain instead of whatever the runner ships.
     container: node:24-slim
+    # contents: write, even though the plan never publishes anything:
+    # semantic-release verifies push access up front (a no-op
+    # `git push --dry-run` of the current commit) in dry-run mode too, and a
+    # read-only GITHUB_TOKEN fails that probe with EGITNOPERMISSION/403.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.semrel.outputs.version }}
     steps:


### PR DESCRIPTION
semantic-release verifies push access up front — a no-op 'git push --dry-run' of the current commit — even in --dry-run mode, and the plan job's read-only GITHUB_TOKEN failed that probe with EGITNOPERMISSION (403 for github-actions[bot]). Give the job contents: write; it still publishes nothing (the dry-run never tags), the permission only satisfies the probe.