### PR TITLE
ci: fix the exec verifyReleaseCmd JS-template SyntaxError

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -23,6 +23,10 @@ plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
   # Exports the computed version to the workflow (runs in the verifyRelease
-  # phase, so it fires in --dry-run "plan" mode too). No-op outside Actions.
+  # phase, so it fires in --dry-run "plan" mode too). NOTE: the exec plugin
+  # renders the command as a JS template literal, so every ${...} must be a
+  # valid JS expression — bash forms like ${GITHUB_OUTPUT:-/dev/null} throw a
+  # SyntaxError at run time. Hence the brace-less $GITHUB_OUTPUT, which the
+  # template pass leaves alone (Actions always sets it).
   - - "@semantic-release/exec"
-    - verifyReleaseCmd: 'echo "version=${nextRelease.version}" >> "${GITHUB_OUTPUT:-/dev/null}"'
+    - verifyReleaseCmd: 'echo "version=${nextRelease.version}" >> "$GITHUB_OUTPUT"'


### PR DESCRIPTION
@semantic-release/exec renders the command as a JS template literal, so the bash default-expansion ${GITHUB_OUTPUT:-/dev/null} was parsed as a JS expression and threw 'SyntaxError: Unexpected token :' in the verifyRelease phase — after the analysis had already resolved 0.5.0. Use brace-less $GITHUB_OUTPUT, which the template pass leaves alone (Actions always sets it).

Verified offline in node:24-slim with a bare file remote, tag 0.4.14 and a feat commit: the FULL plan flow now passes — analysis resolves 0.5.0, verifyRelease completes, and GITHUB_OUTPUT receives version=0.5.0.