### PR TITLE
ci: make releases manual-only (workflow_dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,15 @@ name: Release
 # =============================================================================
 # WORKFLOW CONFIGURATION
 #
-# Versioning is semantic-release (.releaserc.yml): the version is computed
-# from Conventional Commits since the last release tag — fix → patch, feat →
-# minor, BREAKING CHANGE → major. A push to main with no release-worthy
-# commits is a clean no-op (the plan job resolves no version and the release
-# job is skipped). workflow_dispatch just re-evaluates the same rules; there
-# is no manual version input anymore.
+# Releases are MANUAL: dispatch this workflow from main when you decide to
+# ship. Versioning stays automatic (semantic-release, .releaserc.yml): the
+# version is computed from the Conventional Commits since the last release
+# tag — fix → patch, feat → minor, BREAKING CHANGE → major; there is no
+# version input. A dispatch with no release-worthy commits is a clean no-op
+# (the plan job resolves no version and the release job is skipped).
+#
+# Deliberately NOT triggered on push: merging to main must never ship a
+# release by itself — the dispatch is the human "ship it" decision.
 #
 # The workflow file name and ref matter beyond aesthetics: the self-updater
 # pins the cosign signing identity to release.yml@refs/heads/main
@@ -17,12 +20,10 @@ name: Release
 # =============================================================================
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
-# One release at a time: two merges racing would both compute the same next
-# version and the loser's tag push would fail mid-release.
+# One release at a time: two dispatches racing would both compute the same
+# next version and the loser's tag push would fail mid-release.
 concurrency:
   group: release
   cancel-in-progress: false

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -19,18 +19,24 @@ nothing to any release.
 
 ## Flow
 
-1. Merge `develop` into `main` (or push to `main`).
-2. [release.yml](../../.github/workflows/release.yml) runs:
-   - **plan** — `semantic-release --dry-run` resolves the next version from the
-     commits. No release-worthy commits → the run ends here as a no-op.
+Releases are **manual**: merging to `main` never ships anything by itself.
+When you decide to ship, dispatch the workflow from `main`:
+
+```bash
+gh workflow run release.yml --ref main
+```
+
+1. [release.yml](../../.github/workflows/release.yml) then runs:
+   - **plan** — `semantic-release --dry-run` resolves the next version from
+     the commits since the last tag. No release-worthy commits → the run ends
+     here as a no-op.
    - **release** (macOS runner) — lint + unit-test gates, signing setup, then
      `semantic-release` creates and pushes the bare `x.y.z` tag, and
      **GoReleaser** builds, signs and publishes the GitHub Release against it.
    - **verify** — the published Windows/macOS assets are downloaded on real
      runners and their signatures verified; a failure yanks the release + tag.
-3. `workflow_dispatch` on `main` just re-evaluates the same rules (useful to
-   retry after a rolled-back failure). Dispatching from any other branch fails
-   the guard step by design.
+2. Re-dispatching after a rolled-back failure is safe (same rules re-apply).
+   Dispatching from any other branch fails the guard step by design.
 
 ## Invariants (do not break)
 


### PR DESCRIPTION
Drop the push trigger from the release workflow: merging to main must never ship a release by itself — the dispatch is the human 'ship it' decision, restoring the pre-semantic-release operating model. The versioning stays automatic (semantic-release computes x.y.z from the conventional commits since the last tag; a dispatch with nothing release-worthy is a clean no-op). Docs updated accordingly.